### PR TITLE
test: Add test for Atom feed with only rel=self link

### DIFF
--- a/RSSAppTests/Helpers/TestFixtures.swift
+++ b/RSSAppTests/Helpers/TestFixtures.swift
@@ -211,6 +211,23 @@ enum TestFixtures {
         </feed>
         """
 
+    static let atomSelfLinkOnlyXML = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Self Link Only Feed</title>
+            <link rel="self" type="application/atom+xml" href="https://example.com/atom.xml" />
+            <id>https://example.com/atom.xml</id>
+            <updated>2026-04-01T00:00:00Z</updated>
+            <entry>
+                <title>Entry One</title>
+                <link rel="alternate" href="https://example.com/entry-1" />
+                <id>entry-1-id</id>
+                <published>2026-04-01T10:00:00Z</published>
+                <summary>An entry in a self-link-only feed</summary>
+            </entry>
+        </feed>
+        """
+
     static let atomCategoriesXML = """
         <?xml version="1.0" encoding="UTF-8"?>
         <feed xmlns="http://www.w3.org/2005/Atom">

--- a/RSSAppTests/Services/RSSParsingServiceTests.swift
+++ b/RSSAppTests/Services/RSSParsingServiceTests.swift
@@ -310,6 +310,16 @@ struct RSSParsingServiceTests {
         #expect(feed.link?.absoluteString == "https://example.com")
     }
 
+    @Test("Atom feed with only rel=self link produces nil feed link")
+    func atomSelfLinkOnly() throws {
+        let data = Data(TestFixtures.atomSelfLinkOnlyXML.utf8)
+        let feed = try service.parse(data)
+
+        #expect(feed.link == nil)
+        #expect(feed.title == "Self Link Only Feed")
+        #expect(feed.articles.count == 1)
+    }
+
     @Test("Atom feed with no subtitle has empty description")
     func atomNoSubtitle() throws {
         let data = Data(TestFixtures.atomNoContentXML.utf8)


### PR DESCRIPTION
## Summary
- Add test documenting that `feed.link` is `nil` when an Atom feed provides only a `<link rel="self">` and no `<link rel="alternate">`
- Add `atomSelfLinkOnlyXML` fixture for this scenario

Closes #23

## Test plan
- [x] New `atomSelfLinkOnly()` test passes
- [x] Full test suite passes (`** TEST SUCCEEDED **`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)