### PR TITLE
test: Add test for Atom category double-count prevention

### DIFF
--- a/RSSAppTests/Helpers/TestFixtures.swift
+++ b/RSSAppTests/Helpers/TestFixtures.swift
@@ -248,6 +248,25 @@ enum TestFixtures {
         </feed>
         """
 
+    static let atomCategoryDoubleCountXML = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>Double Count Feed</title>
+            <link rel="alternate" href="https://example.com" />
+            <id>https://example.com/dc-feed</id>
+            <updated>2026-04-01T00:00:00Z</updated>
+            <entry>
+                <title>Double Count Entry</title>
+                <link rel="alternate" href="https://example.com/dc-entry" />
+                <id>dc-entry-id</id>
+                <published>2026-04-01T10:00:00Z</published>
+                <category term="tech">Technology</category>
+                <category term="swift">Swift Programming</category>
+                <summary>Entry with category term and text content</summary>
+            </entry>
+        </feed>
+        """
+
     static let rssCategoriesXML = """
         <?xml version="1.0" encoding="UTF-8"?>
         <rss version="2.0">

--- a/RSSAppTests/Services/RSSParsingServiceTests.swift
+++ b/RSSAppTests/Services/RSSParsingServiceTests.swift
@@ -476,6 +476,16 @@ struct RSSParsingServiceTests {
         #expect(entry.categories == ["swift", "ios", "development"])
     }
 
+    @Test("Atom category with term attribute and text content is not double-counted")
+    func atomCategoryDoubleCountPrevention() throws {
+        let data = Data(TestFixtures.atomCategoryDoubleCountXML.utf8)
+        let feed = try service.parse(data)
+        let entry = feed.articles[0]
+
+        #expect(entry.categories == ["tech", "swift"])
+        #expect(entry.categories.count == 2)
+    }
+
     @Test("RSS category text content is extracted")
     func rssCategoryText() throws {
         let data = Data(TestFixtures.rssCategoriesXML.utf8)


### PR DESCRIPTION
## Summary
- Add test verifying that `<category term="X">text</category>` produces only one category entry (the `term` value), not two
- Add `atomCategoryDoubleCountXML` fixture with categories that have both `term` attributes and text content

Closes #25

## Test plan
- [x] New `atomCategoryDoubleCountPrevention()` test passes
- [x] Full test suite passes (`** TEST SUCCEEDED **`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)