### PR TITLE
fix: Add re-entrancy guard to AddFeedViewModel.addFeed()

### DIFF
--- a/RSSApp/ViewModels/AddFeedViewModel.swift
+++ b/RSSApp/ViewModels/AddFeedViewModel.swift
@@ -28,6 +28,7 @@ final class AddFeedViewModel {
     }
 
     func addFeed() async {
+        guard !isValidating else { return }
         Self.logger.debug("addFeed() called with input: '\(self.urlInput, privacy: .public)'")
         errorMessage = nil
 

--- a/RSSAppTests/ViewModels/AddFeedViewModelTests.swift
+++ b/RSSAppTests/ViewModels/AddFeedViewModelTests.swift
@@ -150,6 +150,22 @@ struct AddFeedViewModelTests {
         #expect(viewModel.canSubmit == false)
     }
 
+    @Test("addFeed is a no-op when already validating")
+    @MainActor
+    func addFeedReentrancyGuard() async {
+        let mockFetching = MockFeedFetchingService()
+        mockFetching.feedToReturn = TestFixtures.makeFeed()
+        let mockPersistence = MockFeedPersistenceService()
+
+        let viewModel = AddFeedViewModel(feedFetching: mockFetching, persistence: mockPersistence)
+        viewModel.urlInput = "https://example.com/feed"
+        viewModel.isValidating = true
+        await viewModel.addFeed()
+
+        #expect(viewModel.didAddFeed == false)
+        #expect(mockPersistence.feeds.isEmpty)
+    }
+
     @Test("addFeed detects duplicate when input omits scheme")
     @MainActor
     func addFeedDuplicateWithSchemeNormalization() async {


### PR DESCRIPTION
## Summary
- Add `guard !isValidating else { return }` at top of `addFeed()` to prevent concurrent invocations
- Matches existing pattern in `EditFeedViewModel.saveFeed()`

Closes #31

## Test plan
- [x] New `addFeedReentrancyGuard()` test verifies the guard
- [x] All AddFeedViewModel tests pass
- [x] Full test suite passes (`** TEST SUCCEEDED **`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)