### PR TITLE
test: Restore FeedViewModel and OPML import test coverage

### DIFF
--- a/RSSAppTests/Mocks/MockFeedPersistenceService.swift
+++ b/RSSAppTests/Mocks/MockFeedPersistenceService.swift
@@ -10,9 +10,11 @@ final class MockFeedPersistenceService: FeedPersisting {
     var feeds: [PersistentFeed] = []
     var errorToThrow: (any Error)?
     var unreadCountError: (any Error)?
+    var addFeedFailureAfterCount: Int?
 
     var articlesByFeedID: [UUID: [PersistentArticle]] = [:]
     private var contentByArticleID: [String: PersistentArticleContent] = [:]
+    private var addFeedCallCount = 0
 
     // MARK: - Feed Operations
 
@@ -23,6 +25,10 @@ final class MockFeedPersistenceService: FeedPersisting {
 
     func addFeed(_ feed: PersistentFeed) throws {
         if let error = errorToThrow { throw error }
+        if let limit = addFeedFailureAfterCount, addFeedCallCount >= limit {
+            throw NSError(domain: "MockPersistence", code: 1, userInfo: [NSLocalizedDescriptionKey: "Simulated persistence failure"])
+        }
+        addFeedCallCount += 1
         feeds.append(feed)
     }
 

--- a/RSSAppTests/ViewModels/FeedListViewModelTests.swift
+++ b/RSSAppTests/ViewModels/FeedListViewModelTests.swift
@@ -551,6 +551,46 @@ struct FeedListViewModelTests {
         #expect(viewModel.opmlImportResult?.addedCount == 2)
     }
 
+    @Test("importOPML deduplicates within the same file")
+    @MainActor
+    func importOPMLIntraFileDuplicates() {
+        let mockPersistence = MockFeedPersistenceService()
+        let mockOPML = MockOPMLService()
+        mockOPML.entriesToReturn = [
+            TestFixtures.makeOPMLFeedEntry(title: "Feed A", feedURL: URL(string: "https://a.com/feed")!),
+            TestFixtures.makeOPMLFeedEntry(title: "Feed A Dupe", feedURL: URL(string: "https://a.com/feed")!),
+            TestFixtures.makeOPMLFeedEntry(title: "Feed B", feedURL: URL(string: "https://b.com/feed")!),
+        ]
+
+        let viewModel = FeedListViewModel(persistence: mockPersistence, opmlService: mockOPML)
+        viewModel.importOPML(from: Data())
+
+        #expect(viewModel.feeds.count == 2)
+        #expect(viewModel.opmlImportResult?.addedCount == 2)
+        #expect(viewModel.opmlImportResult?.skippedCount == 1)
+    }
+
+    @Test("importOPML aborts early on persistence failure mid-import")
+    @MainActor
+    func importOPMLPersistenceFailureMidImport() {
+        let mockPersistence = MockFeedPersistenceService()
+        // First addFeed succeeds, second fails
+        mockPersistence.addFeedFailureAfterCount = 1
+        let mockOPML = MockOPMLService()
+        mockOPML.entriesToReturn = [
+            TestFixtures.makeOPMLFeedEntry(title: "Feed A", feedURL: URL(string: "https://a.com/feed")!),
+            TestFixtures.makeOPMLFeedEntry(title: "Feed B", feedURL: URL(string: "https://b.com/feed")!),
+            TestFixtures.makeOPMLFeedEntry(title: "Feed C", feedURL: URL(string: "https://c.com/feed")!),
+        ]
+
+        let viewModel = FeedListViewModel(persistence: mockPersistence, opmlService: mockOPML)
+        viewModel.importOPML(from: Data())
+
+        // Only the first feed should have been added — import aborts on second
+        #expect(viewModel.feeds.count == 1)
+        #expect(viewModel.opmlImportResult == nil)
+    }
+
     // MARK: - 304 Not Modified
 
     @Test("refreshAllFeeds handles 304 Not Modified")

--- a/RSSAppTests/ViewModels/FeedViewModelTests.swift
+++ b/RSSAppTests/ViewModels/FeedViewModelTests.swift
@@ -192,6 +192,55 @@ struct FeedViewModelTests {
         #expect(article.isRead == false)
     }
 
+    @Test("loadFeed clears error on successful retry")
+    @MainActor
+    func loadFeedClearsErrorOnRetry() async {
+        let feed = TestFixtures.makePersistentFeed(feedURL: URL(string: "https://example.com/feed")!)
+        let mock = MockFeedFetchingService()
+        mock.errorToThrow = FeedFetchingError.invalidResponse(statusCode: 500)
+        let mockPersistence = MockFeedPersistenceService()
+
+        let viewModel = FeedViewModel(feed: feed, feedFetching: mock, persistence: mockPersistence)
+        await viewModel.loadFeed()
+        #expect(viewModel.errorMessage != nil)
+
+        // Retry with success
+        mock.errorToThrow = nil
+        mock.feedToReturn = TestFixtures.makeFeed(articles: [
+            TestFixtures.makeArticle(id: "1", title: "Article"),
+        ])
+        await viewModel.loadFeed()
+
+        #expect(viewModel.errorMessage == nil)
+        #expect(viewModel.articles.count == 1)
+    }
+
+    @Test("loadFeed accumulates articles via upsert")
+    @MainActor
+    func loadFeedAccumulatesArticles() async {
+        let feed = TestFixtures.makePersistentFeed(feedURL: URL(string: "https://example.com/feed")!)
+        let mock = MockFeedFetchingService()
+        let mockPersistence = MockFeedPersistenceService()
+        mockPersistence.feeds = [feed]
+
+        // First load: 2 articles
+        mock.feedToReturn = TestFixtures.makeFeed(articles: [
+            TestFixtures.makeArticle(id: "1", title: "First"),
+            TestFixtures.makeArticle(id: "2", title: "Second"),
+        ])
+        let viewModel = FeedViewModel(feed: feed, feedFetching: mock, persistence: mockPersistence)
+        await viewModel.loadFeed()
+        #expect(viewModel.articles.count == 2)
+
+        // Second load: 1 new + 1 existing (should have 3 total after upsert)
+        mock.feedToReturn = TestFixtures.makeFeed(articles: [
+            TestFixtures.makeArticle(id: "2", title: "Second Updated"),
+            TestFixtures.makeArticle(id: "3", title: "Third"),
+        ])
+        await viewModel.loadFeed()
+        #expect(viewModel.articles.count == 3)
+    }
+
     @Test("markAsRead sets errorMessage on persistence failure")
     @MainActor
     func markAsReadPersistenceError() {


### PR DESCRIPTION
## Summary
- Add error-then-retry and article accumulation via upsert tests for FeedViewModel
- Add intra-file duplicate detection and persistence failure mid-import tests for OPML import
- Add `addFeedFailureAfterCount` error injection to MockFeedPersistenceService

Closes #34

## Test plan
- [x] `loadFeedClearsErrorOnRetry()` — error clears on successful retry
- [x] `loadFeedAccumulatesArticles()` — upsert adds new articles, keeps existing
- [x] `importOPMLIntraFileDuplicates()` — duplicate URLs within file detected
- [x] `importOPMLPersistenceFailureMidImport()` — import aborts early, partial feeds preserved
- [x] Full test suite passes (`** TEST SUCCEEDED **`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)