### PR TITLE
fix: Reduce excessive modelContext.save() calls in persistence service

### DIFF
--- a/RSSApp/Services/FeedPersistenceService.swift
+++ b/RSSApp/Services/FeedPersistenceService.swift
@@ -29,6 +29,10 @@ protocol FeedPersisting: Sendable {
 
     func cachedContent(for article: PersistentArticle) throws -> PersistentArticleContent?
     func cacheContent(_ content: ArticleContent, for article: PersistentArticle) throws
+
+    // MARK: Persistence
+
+    func save() throws
 }
 
 // MARK: - SwiftData Implementation
@@ -77,14 +81,12 @@ final class SwiftDataFeedPersistenceService: FeedPersisting {
         feed.lastRefreshDate = Date()
         feed.lastFetchError = nil
         feed.lastFetchErrorDate = nil
-        try modelContext.save()
         Self.logger.debug("Updated metadata for '\(title, privacy: .public)'")
     }
 
     func updateFeedError(_ feed: PersistentFeed, error: String?) throws {
         feed.lastFetchError = error
         feed.lastFetchErrorDate = error != nil ? Date() : nil
-        try modelContext.save()
         Self.logger.debug("Updated error state for '\(feed.title, privacy: .public)'")
     }
 
@@ -99,7 +101,6 @@ final class SwiftDataFeedPersistenceService: FeedPersisting {
     func updateFeedCacheHeaders(_ feed: PersistentFeed, etag: String?, lastModified: String?) throws {
         feed.etag = etag
         feed.lastModifiedHeader = lastModified
-        try modelContext.save()
         Self.logger.debug("Updated cache headers for '\(feed.title, privacy: .public)'")
     }
 
@@ -149,9 +150,6 @@ final class SwiftDataFeedPersistenceService: FeedPersisting {
             insertedCount += 1
         }
 
-        if insertedCount > 0 {
-            try modelContext.save()
-        }
         Self.logger.debug("Upserted articles for '\(feed.title, privacy: .public)': \(insertedCount, privacy: .public) new, \(articles.count - insertedCount, privacy: .public) existing")
     }
 
@@ -160,6 +158,10 @@ final class SwiftDataFeedPersistenceService: FeedPersisting {
         article.readDate = isRead ? Date() : nil
         try modelContext.save()
         Self.logger.debug("Marked article '\(article.title, privacy: .public)' as \(isRead ? "read" : "unread", privacy: .public)")
+    }
+
+    func save() throws {
+        try modelContext.save()
     }
 
     func unreadCount(for feed: PersistentFeed) throws -> Int {

--- a/RSSApp/ViewModels/FeedListViewModel.swift
+++ b/RSSApp/ViewModels/FeedListViewModel.swift
@@ -290,6 +290,12 @@ final class FeedListViewModel {
             }
         }
 
+        do {
+            try persistence.save()
+        } catch {
+            Self.logger.error("Failed to save after refresh: \(error, privacy: .public)")
+        }
+
         loadFeeds()
         Self.logger.notice("Refresh complete: \(self.feeds.count - failureCount, privacy: .public) updated, \(failureCount, privacy: .public) failed")
 

--- a/RSSApp/ViewModels/FeedViewModel.swift
+++ b/RSSApp/ViewModels/FeedViewModel.swift
@@ -51,6 +51,7 @@ final class FeedViewModel {
             let rssFeed = try await feedFetching.fetchFeed(from: feed.feedURL)
             feedTitle = rssFeed.title
             try persistence.upsertArticles(rssFeed.articles, for: feed)
+            try persistence.save()
             articles = try persistence.articles(for: feed)
             Self.logger.notice("Feed loaded: \(self.articles.count, privacy: .public) articles")
         } catch {

--- a/RSSAppTests/Mocks/MockFeedPersistenceService.swift
+++ b/RSSAppTests/Mocks/MockFeedPersistenceService.swift
@@ -114,4 +114,10 @@ final class MockFeedPersistenceService: FeedPersisting {
         persistent.article = article
         contentByArticleID[article.articleID] = persistent
     }
+
+    // MARK: - Persistence
+
+    func save() throws {
+        if let error = errorToThrow { throw error }
+    }
 }


### PR DESCRIPTION
## Summary
- Add `save()` to `FeedPersisting` protocol for caller-controlled batch saves
- Remove per-method `save()` from `updateFeedMetadata`, `updateFeedError`, `updateFeedCacheHeaders`, `upsertArticles`
- During `refreshAllFeeds`, reduces 3 saves per feed to 1 batch save after all feeds

Closes #35

## Test plan
- [x] Full test suite passes (`** TEST SUCCEEDED **`)
- [x] No behavior change — same data is saved, fewer disk flushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)