### PR TITLE
fix: Use conditional HTTP requests in FeedViewModel.loadFeed()

### DIFF
--- a/RSSApp/ViewModels/FeedViewModel.swift
+++ b/RSSApp/ViewModels/FeedViewModel.swift
@@ -48,12 +48,21 @@ final class FeedViewModel {
         defer { isLoading = false }
 
         do {
-            let rssFeed = try await feedFetching.fetchFeed(from: feed.feedURL)
-            feedTitle = rssFeed.title
-            try persistence.upsertArticles(rssFeed.articles, for: feed)
-            try persistence.save()
-            articles = try persistence.articles(for: feed)
-            Self.logger.notice("Feed loaded: \(self.articles.count, privacy: .public) articles")
+            let result = try await feedFetching.fetchFeed(
+                from: feed.feedURL,
+                etag: feed.etag,
+                lastModified: feed.lastModifiedHeader
+            )
+            if let result {
+                feedTitle = result.feed.title
+                try persistence.upsertArticles(result.feed.articles, for: feed)
+                try persistence.updateFeedCacheHeaders(feed, etag: result.etag, lastModified: result.lastModified)
+                try persistence.save()
+                articles = try persistence.articles(for: feed)
+                Self.logger.notice("Feed loaded: \(self.articles.count, privacy: .public) articles")
+            } else {
+                Self.logger.debug("Feed unchanged (304) for '\(self.feed.title, privacy: .public)'")
+            }
         } catch {
             if articles.isEmpty {
                 errorMessage = error.localizedDescription


### PR DESCRIPTION
## Summary
- Use ETag/If-Modified-Since headers in `loadFeed()` to avoid re-downloading unchanged feeds
- Skip upsert on 304 Not Modified — cached articles are already displayed
- Update cache headers after successful fetch for future conditional requests

Closes #36

## Test plan
- [x] Full test suite passes (`** TEST SUCCEEDED **`)
- [x] Existing FeedViewModel tests verify behavior through mock

🤖 Generated with [Claude Code](https://claude.com/claude-code)