### PR TITLE
refactor: Use dependency injection for FeedIconService in FeedIconView

### DIFF
--- a/RSSApp/ViewModels/FeedListViewModel.swift
+++ b/RSSApp/ViewModels/FeedListViewModel.swift
@@ -20,7 +20,7 @@ final class FeedListViewModel {
     private let persistence: FeedPersisting
     private let opmlService: OPMLServing
     private let feedFetching: FeedFetching
-    private let feedIconService: FeedIconResolving
+    let feedIconService: FeedIconResolving
 
     init(
         persistence: FeedPersisting,

--- a/RSSApp/Views/FeedIconView.swift
+++ b/RSSApp/Views/FeedIconView.swift
@@ -6,6 +6,7 @@ struct FeedIconView: View {
     // RATIONALE: iconURL is not read directly — it exists so SwiftUI detects a property
     // change and re-evaluates the body when the icon becomes available after caching.
     let iconURL: URL?
+    let iconService: FeedIconResolving
 
     @State private var iconImage: UIImage?
 
@@ -27,7 +28,7 @@ struct FeedIconView: View {
         }
         .frame(width: Self.iconSize, height: Self.iconSize)
         .task(id: iconURL) {
-            guard let fileURL = FeedIconService().cachedIconFileURL(for: feedID) else {
+            guard let fileURL = iconService.cachedIconFileURL(for: feedID) else {
                 iconImage = nil
                 return
             }

--- a/RSSApp/Views/FeedListView.swift
+++ b/RSSApp/Views/FeedListView.swift
@@ -128,7 +128,8 @@ struct FeedListView: View {
                     NavigationLink(value: feed.id) {
                         FeedRowView(
                             feed: feed,
-                            unreadCount: viewModel.unreadCount(for: feed)
+                            unreadCount: viewModel.unreadCount(for: feed),
+                            iconService: viewModel.feedIconService
                         )
                     }
                     .swipeActions(edge: .leading) {

--- a/RSSApp/Views/FeedRowView.swift
+++ b/RSSApp/Views/FeedRowView.swift
@@ -3,10 +3,11 @@ import SwiftUI
 struct FeedRowView: View {
     let feed: PersistentFeed
     let unreadCount: Int
+    let iconService: FeedIconResolving
 
     var body: some View {
         HStack(spacing: 10) {
-            FeedIconView(feedID: feed.id, iconURL: feed.iconURL)
+            FeedIconView(feedID: feed.id, iconURL: feed.iconURL, iconService: iconService)
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(feed.title)


### PR DESCRIPTION
## Summary
- Replace hardcoded `FeedIconService()` instantiation in `FeedIconView` with an injected `FeedIconResolving` dependency, making the view consistent with the project's DI architecture and testable in isolation
- Thread the icon service from `FeedListViewModel` → `FeedListView` → `FeedRowView` → `FeedIconView`

Closes #55

## Test plan
- [x] Built successfully for iOS 26
- [x] All existing tests pass
- [ ] Feed icons still display correctly on the Feeds page

🤖 Generated with [Claude Code](https://claude.com/claude-code)