### PR TITLE
test: Add icon resolution assertions to view model tests

### DIFF
--- a/RSSAppTests/ViewModels/AddFeedViewModelTests.swift
+++ b/RSSAppTests/ViewModels/AddFeedViewModelTests.swift
@@ -184,6 +184,59 @@ struct AddFeedViewModelTests {
         #expect(viewModel.errorMessage == "You are already subscribed to this feed.")
     }
 
+    // MARK: - Icon Resolution
+
+    @Test("addFeed triggers icon resolution on success")
+    @MainActor
+    func addFeedTriggersIconResolution() async {
+        let mockFetching = MockFeedFetchingService()
+        mockFetching.feedToReturn = TestFixtures.makeFeed(
+            title: "My Feed",
+            link: URL(string: "https://example.com"),
+            imageURL: URL(string: "https://example.com/logo.png")
+        )
+        let mockPersistence = MockFeedPersistenceService()
+        let mockIconService = MockFeedIconService()
+        mockIconService.candidateURLs = [URL(string: "https://example.com/icon.png")!]
+        mockIconService.cacheResult = true
+
+        let viewModel = AddFeedViewModel(
+            feedFetching: mockFetching,
+            persistence: mockPersistence,
+            feedIconService: mockIconService
+        )
+        viewModel.urlInput = "https://example.com/feed"
+        await viewModel.addFeed()
+
+        // Allow fire-and-forget icon resolution task to complete
+        for _ in 0..<10 { await Task.yield() }
+
+        #expect(viewModel.didAddFeed == true)
+        #expect(mockIconService.resolveCallCount == 1)
+        #expect(mockIconService.cacheCallCount == 1)
+    }
+
+    @Test("addFeed does not trigger icon resolution on fetch failure")
+    @MainActor
+    func addFeedSkipsIconResolutionOnFailure() async {
+        let mockFetching = MockFeedFetchingService()
+        mockFetching.errorToThrow = FeedFetchingError.invalidResponse(statusCode: 500)
+        let mockPersistence = MockFeedPersistenceService()
+        let mockIconService = MockFeedIconService()
+
+        let viewModel = AddFeedViewModel(
+            feedFetching: mockFetching,
+            persistence: mockPersistence,
+            feedIconService: mockIconService
+        )
+        viewModel.urlInput = "https://example.com/feed"
+        await viewModel.addFeed()
+
+        #expect(viewModel.didAddFeed == false)
+        #expect(mockIconService.resolveCallCount == 0)
+        #expect(mockIconService.cacheCallCount == 0)
+    }
+
     @Test("addFeed clears previous error on retry")
     @MainActor
     func addFeedClearsPreviousError() async {

--- a/RSSAppTests/ViewModels/FeedListViewModelTests.swift
+++ b/RSSAppTests/ViewModels/FeedListViewModelTests.swift
@@ -117,6 +117,46 @@ struct FeedListViewModelTests {
         #expect(viewModel.errorMessage != nil)
     }
 
+    // MARK: - Icon Cache Cleanup
+
+    @Test("removeFeed deletes cached icon")
+    @MainActor
+    func removeFeedDeletesCachedIcon() {
+        let feed = TestFixtures.makePersistentFeed(title: "Remove Me")
+        let mockPersistence = MockFeedPersistenceService()
+        mockPersistence.feeds = [feed]
+        let mockIconService = MockFeedIconService()
+
+        let viewModel = FeedListViewModel(
+            persistence: mockPersistence,
+            feedIconService: mockIconService
+        )
+        viewModel.loadFeeds()
+        viewModel.removeFeed(feed)
+
+        #expect(mockIconService.deleteCallCount == 1)
+    }
+
+    @Test("removeFeed at IndexSet deletes cached icons for each removed feed")
+    @MainActor
+    func removeFeedAtIndexSetDeletesCachedIcons() {
+        let feed1 = TestFixtures.makePersistentFeed(title: "First")
+        let feed2 = TestFixtures.makePersistentFeed(title: "Second")
+        let feed3 = TestFixtures.makePersistentFeed(title: "Third")
+        let mockPersistence = MockFeedPersistenceService()
+        mockPersistence.feeds = [feed1, feed2, feed3]
+        let mockIconService = MockFeedIconService()
+
+        let viewModel = FeedListViewModel(
+            persistence: mockPersistence,
+            feedIconService: mockIconService
+        )
+        viewModel.loadFeeds()
+        viewModel.removeFeed(at: IndexSet([0, 2]))
+
+        #expect(mockIconService.deleteCallCount == 2)
+    }
+
     // MARK: - Unread Counts
 
     @Test("loadFeeds populates unread counts")
@@ -590,6 +630,61 @@ struct FeedListViewModelTests {
         // Only the first feed should have been added — import aborts on second
         #expect(viewModel.feeds.count == 1)
         #expect(viewModel.opmlImportResult == nil)
+    }
+
+    // MARK: - Icon Resolution During Refresh
+
+    @Test("refreshAllFeeds resolves icons for fetched feeds")
+    @MainActor
+    func refreshAllFeedsResolvesIcons() async {
+        let url = URL(string: "https://example.com/feed")!
+        let feed = TestFixtures.makePersistentFeed(feedURL: url)
+
+        let mockPersistence = MockFeedPersistenceService()
+        mockPersistence.feeds = [feed]
+        let mockFetching = MockFeedFetchingService()
+        mockFetching.feedsByURL = [url: TestFixtures.makeFeed()]
+        let mockIconService = MockFeedIconService()
+
+        let viewModel = FeedListViewModel(
+            persistence: mockPersistence,
+            feedFetching: mockFetching,
+            feedIconService: mockIconService
+        )
+        viewModel.loadFeeds()
+        await viewModel.refreshAllFeeds()
+
+        // Allow fire-and-forget icon resolution tasks to complete
+        for _ in 0..<10 { await Task.yield() }
+
+        #expect(mockIconService.resolveCallCount == 1)
+    }
+
+    @Test("refreshAllFeeds skips icon resolution when icon already cached")
+    @MainActor
+    func refreshAllFeedsSkipsIconWhenCached() async {
+        let url = URL(string: "https://example.com/feed")!
+        let feed = TestFixtures.makePersistentFeed(feedURL: url)
+
+        let mockPersistence = MockFeedPersistenceService()
+        mockPersistence.feeds = [feed]
+        let mockFetching = MockFeedFetchingService()
+        mockFetching.feedsByURL = [url: TestFixtures.makeFeed()]
+        let mockIconService = MockFeedIconService()
+        mockIconService.cachedFileURL = URL(filePath: "/tmp/cached-icon.png")
+
+        let viewModel = FeedListViewModel(
+            persistence: mockPersistence,
+            feedFetching: mockFetching,
+            feedIconService: mockIconService
+        )
+        viewModel.loadFeeds()
+        await viewModel.refreshAllFeeds()
+
+        // Allow fire-and-forget icon resolution tasks to complete
+        for _ in 0..<10 { await Task.yield() }
+
+        #expect(mockIconService.resolveCallCount == 0)
     }
 
     // MARK: - 304 Not Modified


### PR DESCRIPTION
## Summary
- Add test coverage for icon service interactions that were previously unverified
- Inject `MockFeedIconService` in `AddFeedViewModelTests` and verify icon resolution triggers on success / is skipped on failure
- Assert `deleteCachedIcon` is called when removing feeds in `FeedListViewModelTests`
- Verify icon resolution triggers during refresh and is skipped when icons are already cached

Closes #56

## Test plan
- [x] All 6 new tests pass
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)