### PR TITLE
refactor: Add resolveAndCacheIcon orchestrating method to FeedIconResolving

### DIFF
--- a/RSSApp/Services/FeedIconService.swift
+++ b/RSSApp/Services/FeedIconService.swift
@@ -18,6 +18,10 @@ protocol FeedIconResolving: Sendable {
     /// Returns the local file URL for a cached icon, or `nil` if not cached.
     func cachedIconFileURL(for feedID: UUID) -> URL?
 
+    /// Resolves candidate icon URLs and caches the first one that downloads successfully.
+    /// Returns the remote URL of the cached icon, or `nil` if no candidate could be cached.
+    func resolveAndCacheIcon(feedSiteURL: URL?, feedImageURL: URL?, feedID: UUID) async -> URL?
+
     /// Deletes the cached icon file for the given feed.
     func deleteCachedIcon(for feedID: UUID)
 }
@@ -108,6 +112,18 @@ struct FeedIconService: FeedIconResolving {
     func cachedIconFileURL(for feedID: UUID) -> URL? {
         let fileURL = iconFileURL(for: feedID)
         return FileManager.default.fileExists(atPath: fileURL.path(percentEncoded: false)) ? fileURL : nil
+    }
+
+    func resolveAndCacheIcon(feedSiteURL: URL?, feedImageURL: URL?, feedID: UUID) async -> URL? {
+        let candidates = await resolveIconCandidates(feedSiteURL: feedSiteURL, feedImageURL: feedImageURL)
+        for candidate in candidates {
+            let cached = await cacheIcon(from: candidate, feedID: feedID)
+            if cached {
+                return candidate
+            }
+        }
+        Self.logger.debug("No icon cached for feed \(feedID.uuidString, privacy: .public) (\(candidates.count, privacy: .public) candidates tried)")
+        return nil
     }
 
     // RATIONALE: Uses removeItem (permanent delete) rather than trashItem because these are

--- a/RSSApp/ViewModels/AddFeedViewModel.swift
+++ b/RSSApp/ViewModels/AddFeedViewModel.swift
@@ -77,28 +77,21 @@ final class AddFeedViewModel {
             // Fire-and-forget icon resolution
             let iconService = self.feedIconService
             let feedTitle = rssFeed.title
-            let feedID = newFeed.id
             let siteURL = rssFeed.link
             let feedImageURL = rssFeed.imageURL
             let persistenceRef = self.persistence
             Task {
-                let candidates = await iconService.resolveIconCandidates(
+                guard let iconURL = await iconService.resolveAndCacheIcon(
                     feedSiteURL: siteURL,
-                    feedImageURL: feedImageURL
-                )
-                for candidate in candidates {
-                    let cached = await iconService.cacheIcon(from: candidate, feedID: feedID)
-                    if cached {
-                        do {
-                            try persistenceRef.updateFeedIcon(newFeed, iconURL: candidate)
-                            try persistenceRef.save()
-                        } catch {
-                            Self.logger.error("Failed to persist icon for '\(feedTitle, privacy: .public)': \(error, privacy: .public)")
-                        }
-                        return
-                    }
+                    feedImageURL: feedImageURL,
+                    feedID: newFeed.id
+                ) else { return }
+                do {
+                    try persistenceRef.updateFeedIcon(newFeed, iconURL: iconURL)
+                    try persistenceRef.save()
+                } catch {
+                    Self.logger.error("Failed to persist icon for '\(feedTitle, privacy: .public)': \(error, privacy: .public)")
                 }
-                Self.logger.debug("No icon cached for '\(feedTitle, privacy: .public)' (\(candidates.count, privacy: .public) candidates tried)")
             }
         } catch {
             errorMessage = "Could not load feed. Check the URL and try again."

--- a/RSSApp/ViewModels/FeedListViewModel.swift
+++ b/RSSApp/ViewModels/FeedListViewModel.swift
@@ -326,7 +326,6 @@ final class FeedListViewModel {
     }
 
     /// Resolves and caches a feed icon if one is not already cached on disk.
-    /// Tries each candidate URL in priority order until one downloads and caches successfully.
     private func resolveAndCacheIconIfNeeded(
         for feed: PersistentFeed,
         siteURL: URL?,
@@ -336,22 +335,16 @@ final class FeedListViewModel {
             Self.logger.debug("Icon already cached for '\(feed.title, privacy: .public)'")
             return
         }
-        let candidates = await feedIconService.resolveIconCandidates(
+        guard let iconURL = await feedIconService.resolveAndCacheIcon(
             feedSiteURL: siteURL,
-            feedImageURL: feedImageURL
-        )
-        for candidate in candidates {
-            let cached = await feedIconService.cacheIcon(from: candidate, feedID: feed.id)
-            if cached {
-                do {
-                    try persistence.updateFeedIcon(feed, iconURL: candidate)
-                } catch {
-                    Self.logger.error("Failed to persist icon URL for '\(feed.title, privacy: .public)': \(error, privacy: .public)")
-                }
-                return
-            }
+            feedImageURL: feedImageURL,
+            feedID: feed.id
+        ) else { return }
+        do {
+            try persistence.updateFeedIcon(feed, iconURL: iconURL)
+        } catch {
+            Self.logger.error("Failed to persist icon URL for '\(feed.title, privacy: .public)': \(error, privacy: .public)")
         }
-        Self.logger.debug("No icon could be cached for '\(feed.title, privacy: .public)' (\(candidates.count, privacy: .public) candidates tried)")
     }
 
     /// Derives a site root URL from a feed URL (e.g., https://example.com/feed → https://example.com).

--- a/RSSAppTests/Mocks/MockFeedIconService.swift
+++ b/RSSAppTests/Mocks/MockFeedIconService.swift
@@ -8,6 +8,8 @@ final class MockFeedIconService: FeedIconResolving, @unchecked Sendable {
     var cachedFileURL: URL?
     var resolveCallCount = 0
     var cacheCallCount = 0
+    var resolveAndCacheCallCount = 0
+    var resolveAndCacheResult: URL?
     var deleteCallCount = 0
 
     func resolveIconCandidates(feedSiteURL: URL?, feedImageURL: URL?) async -> [URL] {
@@ -22,6 +24,11 @@ final class MockFeedIconService: FeedIconResolving, @unchecked Sendable {
 
     func cachedIconFileURL(for feedID: UUID) -> URL? {
         cachedFileURL
+    }
+
+    func resolveAndCacheIcon(feedSiteURL: URL?, feedImageURL: URL?, feedID: UUID) async -> URL? {
+        resolveAndCacheCallCount += 1
+        return resolveAndCacheResult
     }
 
     func deleteCachedIcon(for feedID: UUID) {

--- a/RSSAppTests/ViewModels/AddFeedViewModelTests.swift
+++ b/RSSAppTests/ViewModels/AddFeedViewModelTests.swift
@@ -197,8 +197,7 @@ struct AddFeedViewModelTests {
         )
         let mockPersistence = MockFeedPersistenceService()
         let mockIconService = MockFeedIconService()
-        mockIconService.candidateURLs = [URL(string: "https://example.com/icon.png")!]
-        mockIconService.cacheResult = true
+        mockIconService.resolveAndCacheResult = URL(string: "https://example.com/icon.png")
 
         let viewModel = AddFeedViewModel(
             feedFetching: mockFetching,
@@ -212,8 +211,7 @@ struct AddFeedViewModelTests {
         for _ in 0..<10 { await Task.yield() }
 
         #expect(viewModel.didAddFeed == true)
-        #expect(mockIconService.resolveCallCount == 1)
-        #expect(mockIconService.cacheCallCount == 1)
+        #expect(mockIconService.resolveAndCacheCallCount == 1)
     }
 
     @Test("addFeed does not trigger icon resolution on fetch failure")
@@ -233,8 +231,7 @@ struct AddFeedViewModelTests {
         await viewModel.addFeed()
 
         #expect(viewModel.didAddFeed == false)
-        #expect(mockIconService.resolveCallCount == 0)
-        #expect(mockIconService.cacheCallCount == 0)
+        #expect(mockIconService.resolveAndCacheCallCount == 0)
     }
 
     @Test("addFeed clears previous error on retry")

--- a/RSSAppTests/ViewModels/FeedListViewModelTests.swift
+++ b/RSSAppTests/ViewModels/FeedListViewModelTests.swift
@@ -657,7 +657,7 @@ struct FeedListViewModelTests {
         // Allow fire-and-forget icon resolution tasks to complete
         for _ in 0..<10 { await Task.yield() }
 
-        #expect(mockIconService.resolveCallCount == 1)
+        #expect(mockIconService.resolveAndCacheCallCount == 1)
     }
 
     @Test("refreshAllFeeds skips icon resolution when icon already cached")
@@ -684,7 +684,7 @@ struct FeedListViewModelTests {
         // Allow fire-and-forget icon resolution tasks to complete
         for _ in 0..<10 { await Task.yield() }
 
-        #expect(mockIconService.resolveCallCount == 0)
+        #expect(mockIconService.resolveAndCacheCallCount == 0)
     }
 
     // MARK: - 304 Not Modified


### PR DESCRIPTION
## Summary
- Centralize the resolve-candidates-then-cache-first-match loop into a single `resolveAndCacheIcon` protocol method
- Eliminates duplication between `AddFeedViewModel` and `FeedListViewModel`
- Both callers now use the orchestrating method; persistence updates remain caller responsibility

Closes #57

## Test plan
- [x] Built successfully for iOS 26
- [x] All existing tests pass (icon resolution tests updated for new method)

🤖 Generated with [Claude Code](https://claude.com/claude-code)