### PR TITLE
fix: Render globe placeholder with background shape in FeedIconView

### DIFF
--- a/RSSApp/Views/FeedIconView.swift
+++ b/RSSApp/Views/FeedIconView.swift
@@ -21,9 +21,12 @@ struct FeedIconView: View {
                     .aspectRatio(contentMode: .fit)
                     .clipShape(RoundedRectangle(cornerRadius: Self.cornerRadius))
             } else {
-                Image(systemName: "globe")
-                    .font(.title2)
-                    .foregroundStyle(.secondary)
+                RoundedRectangle(cornerRadius: Self.cornerRadius)
+                    .fill(Color(.tertiarySystemFill))
+                    .overlay {
+                        Image(systemName: "globe")
+                            .foregroundStyle(.secondary)
+                    }
             }
         }
         .frame(width: Self.iconSize, height: Self.iconSize)


### PR DESCRIPTION
## Summary
- Fixes globe placeholder icon not rendering visibly for feeds without favicons
- Replaces the bare SF Symbol with a `RoundedRectangle` background + globe overlay, ensuring the placeholder is always visible regardless of SwiftUI rendering context
- The `tertiarySystemFill` background adapts to light/dark mode and provides a consistent visual container matching the rounded rectangle clip shape used for actual icons

Closes #53

## Test plan
- [x] Build succeeds for iOS 26
- [x] All 349 existing tests pass
- [ ] Verify globe placeholder renders visibly in feed list for feeds without cached icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)