### PR TITLE
feat: Add model and max tokens configuration to API Settings

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -40,6 +40,7 @@ RSSApp/
 │   ├── HTMLUtilities.swift             # HTML/XML escaping (text + attributes), tag stripping, entity decoding, image extraction, og:image extraction, icon URL extraction
 │   ├── KeychainService.swift           # Keychain wrapper for secure API key storage
 │   ├── MetadataExtractor.swift         # Extracts article title/byline from meta tags and DOM elements
+│   ├── ModelConfigurationValidator.swift # ModelValidation + MaxTokensValidation enums — input validation for model ID and max tokens
 │   ├── OPMLService.swift               # OPMLServing protocol + XMLParser-based OPML parser + XML generator
 │   ├── RSSParsingService.swift         # XMLParser-based RSS 2.0 + Atom parser with XHTML content reconstruction
 │   └── SiteSpecificExtracting.swift    # Protocol for per-hostname content extractors
@@ -113,6 +114,7 @@ RSSAppTests/
 │   ├── KeychainServiceTests.swift      # Save/load/delete/overwrite roundtrips
 │   ├── OPMLServiceTests.swift          # Parse flat/nested/empty OPML, generate + round-trip, XML escaping
 │   ├── MetadataExtractorTests.swift    # Title/byline extraction from meta tags and DOM
+│   ├── ModelConfigurationValidationTests.swift # ModelValidation and MaxTokensValidation input validation
 │   └── RSSParsingServiceTests.swift    # Channel parsing, thumbnails, IDs, edge cases
 ├── ViewModels/
 │   ├── AddFeedViewModelTests.swift         # URL validation, duplicate detection, success/failure
@@ -121,11 +123,9 @@ RSSAppTests/
 │   ├── DiscussionViewModelTests.swift      # Message flow, streaming, no-key behavior
 │   ├── FeedListViewModelTests.swift        # Load, remove by object, remove by IndexSet
 │   └── FeedViewModelTests.swift            # Load success/failure, state transitions
-└── Views/
-    └── ModelConfigurationValidationTests.swift # ModelValidation and MaxTokensValidation enums
 ```
 
-**Total: 55 source files + 1 resource, 42 test source files + 1 fixture.**
+**Total: 56 source files + 1 resource, 42 test source files + 1 fixture.**
 
 ## Component Map
 
@@ -255,7 +255,7 @@ All view models are `@MainActor @Observable`.
 
 `SettingsView` is the top-level settings page, pushed from `FeedListView` via the gear toolbar icon using a `NavigationLink` within `FeedListView`'s `NavigationStack`. Contains `NavigationLink` rows for API Key (pushes `APIKeySettingsView`) and Import/Export (pushes `ImportExportView`). `ImportExportView` (defined in the same file) hosts the OPML import/export functionality previously in the `FeedListView` toolbar menu.
 
-`APIKeySettingsView` provides a `TextField` for pasting an Anthropic API key, Save/Remove buttons, and a status indicator. Saved keys go directly to `KeychainService`. Also includes a "Model Configuration" section with fields for the Claude model identifier (validated: must start with `claude-`, lowercase alphanumeric + hyphens only) and max output tokens (validated: must be a positive integer). Both values are persisted in `UserDefaults` and validated inline with green checkmark / red indicator feedback. Validation logic is in `ModelValidation` and `MaxTokensValidation` enums (defined in the same file). Designed to be pushed from `SettingsView` or presented as a sheet (wrapped in `NavigationStack` by the caller when used as a sheet).
+`APIKeySettingsView` provides a `TextField` for pasting an Anthropic API key, Save/Remove buttons, and a status indicator. Saved keys go directly to `KeychainService`. Also includes a "Model Configuration" section with fields for the Claude model identifier (validated: must start with `claude-`, lowercase alphanumeric + hyphens only) and max output tokens (validated: must be a positive integer). Both values are persisted in `UserDefaults` and validated inline with green checkmark / red indicator feedback. Validation logic is in `ModelValidation` and `MaxTokensValidation` enums in `ModelConfigurationValidator.swift` (under Services). Designed to be pushed from `SettingsView` or presented as a sheet (wrapped in `NavigationStack` by the caller when used as a sheet).
 
 ## Data Flow
 
@@ -373,7 +373,8 @@ RSSAppApp (@main)
 | HTMLUtilities | HTMLUtilitiesTests.swift | Tag stripping, entity decoding (amp, lt, gt, quot, apos, nbsp), whitespace collapse, HTML text escaping (amp, angle brackets, no-op), attribute escaping (amp, quot, lt, gt, no-op, multiple), image extraction (double/single quotes, multiple images, no images), og:image extraction (basic, reversed attributes, missing, case-insensitive, empty) |
 | RSSParsingService | RSSParsingServiceTests.swift | Channel info, article count, basic fields, pubDate, snippets, raw description, thumbnail sources (media:thumbnail, media:content, enclosure, img fallback), thumbnail priority, ID derivation (guid, link), empty channel, malformed XML, empty data, missing fields, empty title, long snippet truncation, Atom XHTML content reconstruction (content, summary, content-overrides-summary, snippet generation, thumbnail extraction), Atom/RSS author extraction, Atom category term attributes, RSS category text, Atom enclosure links, RSS lastBuildDate, Atom feed-level updated date, default author/categories |
 | KeychainService | KeychainServiceTests.swift | Save/load roundtrip, load when empty, delete clears value, overwrite updates value |
-| ClaudeAPIService | ClaudeAPIServiceTests.swift | Request headers, request body JSON encoding, SSE text delta parsing, non-delta event returns nil, malformed JSON returns nil, delta without text returns nil |
+| ClaudeAPIService | ClaudeAPIServiceTests.swift | Request headers, request body JSON encoding (defaults + custom model/maxTokens), UserDefaults reading (default/stored/empty model, default/stored/zero/negative maxTokens, dynamic updates), SSE text delta parsing, non-delta event returns nil, malformed JSON returns nil, delta without text returns nil |
+| ModelValidation + MaxTokensValidation | ModelConfigurationValidationTests.swift | Valid model ID with trimmed value, empty/whitespace, missing prefix, uppercase/spaces/special characters, claude-alone valid; valid positive integer with parsed value, minimum (1), large number, empty/whitespace, zero/negative/non-numeric/decimal invalid |
 | CandidateScorer | CandidateScorerTests.swift | Content node identification in simple pages, scoring with class/id signals, link-density penalty, pruning of unlikely nodes |
 | ContentAssembler | ContentAssemblerTests.swift | Plain text assembly, HTML tag preservation, attribute stripping, nested structure handling |
 | ContentExtractor | ContentExtractorTests.swift | End-to-end extraction from DOM, site-specific extractor fallback, nil handling |

--- a/RSSApp/Services/ClaudeAPIService.swift
+++ b/RSSApp/Services/ClaudeAPIService.swift
@@ -65,7 +65,7 @@ struct ClaudeAPIService: ClaudeAPIServicing {
         }
 
         let request = try buildRequest(url: url, apiKey: apiKey, systemPrompt: systemPrompt, messages: messages)
-        Self.logger.debug("sendMessage() called with \(messages.count, privacy: .public) messages")
+        Self.logger.debug("sendMessage() called with \(messages.count, privacy: .public) messages, model=\(model, privacy: .public), maxTokens=\(maxTokens, privacy: .public)")
 
         return AsyncThrowingStream { continuation in
             Task {

--- a/RSSApp/Services/ModelConfigurationValidator.swift
+++ b/RSSApp/Services/ModelConfigurationValidator.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+enum ModelValidation: Equatable {
+    case valid(String)
+    case empty
+    case invalid(String)
+
+    /// Pattern: lowercase alphanumeric characters, hyphens, and digits.
+    private static let validCharacterSet = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyz0123456789-")
+
+    static func validate(_ input: String) -> ModelValidation {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return .empty }
+        if !trimmed.hasPrefix("claude-") {
+            return .invalid("Model ID must start with 'claude-'")
+        }
+        if trimmed.unicodeScalars.contains(where: { !validCharacterSet.contains($0) }) {
+            return .invalid("Only lowercase letters, digits, and hyphens are allowed")
+        }
+        return .valid(trimmed)
+    }
+}
+
+enum MaxTokensValidation: Equatable {
+    case valid(Int)
+    case empty
+    case invalid(String)
+
+    static func validate(_ input: String) -> MaxTokensValidation {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return .empty }
+        guard let value = Int(trimmed) else {
+            return .invalid("Must be a whole number")
+        }
+        if value < 1 {
+            return .invalid("Must be at least 1")
+        }
+        return .valid(value)
+    }
+}

--- a/RSSApp/Views/APIKeySettingsView.swift
+++ b/RSSApp/Views/APIKeySettingsView.swift
@@ -107,7 +107,7 @@ struct APIKeySettingsView: View {
     private var modelValidationView: some View {
         let result = ModelValidation.validate(modelInput)
         switch result {
-        case .valid:
+        case .valid(_):
             Label("Valid model identifier", systemImage: "checkmark.circle.fill")
                 .font(.caption)
                 .foregroundStyle(.green)
@@ -126,7 +126,7 @@ struct APIKeySettingsView: View {
     private var maxTokensValidationView: some View {
         let result = MaxTokensValidation.validate(maxTokensInput)
         switch result {
-        case .valid:
+        case .valid(_):
             Label("Valid token count", systemImage: "checkmark.circle.fill")
                 .font(.caption)
                 .foregroundStyle(.green)
@@ -159,65 +159,28 @@ struct APIKeySettingsView: View {
     }
 
     private func saveModelIdentifier(_ value: String) {
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty {
+        switch ModelValidation.validate(value) {
+        case .empty:
             UserDefaults.standard.removeObject(forKey: ClaudeAPIService.modelDefaultsKey)
-            Self.logger.debug("Model identifier cleared, will use default")
-        } else if case .valid = ModelValidation.validate(trimmed) {
-            UserDefaults.standard.set(trimmed, forKey: ClaudeAPIService.modelDefaultsKey)
-            Self.logger.debug("Model identifier saved: \(trimmed, privacy: .public)")
+            Self.logger.notice("Model identifier cleared, will use default")
+        case .valid(let validated):
+            UserDefaults.standard.set(validated, forKey: ClaudeAPIService.modelDefaultsKey)
+            Self.logger.notice("Model identifier saved: \(validated, privacy: .public)")
+        case .invalid(let reason):
+            Self.logger.debug("Model identifier input rejected: \(reason, privacy: .public)")
         }
     }
 
     private func saveMaxTokens(_ value: String) {
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty {
+        switch MaxTokensValidation.validate(value) {
+        case .empty:
             UserDefaults.standard.removeObject(forKey: ClaudeAPIService.maxTokensDefaultsKey)
-            Self.logger.debug("Max tokens cleared, will use default")
-        } else if let intValue = Int(trimmed), intValue >= 1 {
-            UserDefaults.standard.set(intValue, forKey: ClaudeAPIService.maxTokensDefaultsKey)
-            Self.logger.debug("Max tokens saved: \(intValue, privacy: .public)")
+            Self.logger.notice("Max tokens cleared, will use default")
+        case .valid(let validated):
+            UserDefaults.standard.set(validated, forKey: ClaudeAPIService.maxTokensDefaultsKey)
+            Self.logger.notice("Max tokens saved: \(validated, privacy: .public)")
+        case .invalid(let reason):
+            Self.logger.debug("Max tokens input rejected: \(reason, privacy: .public)")
         }
-    }
-}
-
-// MARK: - Validation
-
-enum ModelValidation: Equatable {
-    case valid
-    case empty
-    case invalid(String)
-
-    /// Pattern: lowercase alphanumeric characters, hyphens, and digits.
-    private static let validCharacterSet = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyz0123456789-")
-
-    static func validate(_ input: String) -> ModelValidation {
-        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty { return .empty }
-        if !trimmed.hasPrefix("claude-") {
-            return .invalid("Model ID must start with 'claude-'")
-        }
-        if trimmed.unicodeScalars.contains(where: { !validCharacterSet.contains($0) }) {
-            return .invalid("Only lowercase letters, digits, and hyphens are allowed")
-        }
-        return .valid
-    }
-}
-
-enum MaxTokensValidation: Equatable {
-    case valid
-    case empty
-    case invalid(String)
-
-    static func validate(_ input: String) -> MaxTokensValidation {
-        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty { return .empty }
-        guard let value = Int(trimmed) else {
-            return .invalid("Must be a whole number")
-        }
-        if value < 1 {
-            return .invalid("Must be at least 1")
-        }
-        return .valid
     }
 }

--- a/RSSAppTests/Services/ClaudeAPIServiceTests.swift
+++ b/RSSAppTests/Services/ClaudeAPIServiceTests.swift
@@ -9,6 +9,7 @@ struct ClaudeAPIServiceTests {
     private func makeTestDefaults() -> UserDefaults {
         let suiteName = "com.rssapp.test.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
         return defaults
     }
 
@@ -113,6 +114,14 @@ struct ClaudeAPIServiceTests {
     func maxTokensZero() {
         let defaults = makeTestDefaults()
         defaults.set(0, forKey: ClaudeAPIService.maxTokensDefaultsKey)
+        let service = ClaudeAPIService(defaults: defaults)
+        #expect(service.maxTokens == 4096)
+    }
+
+    @Test("maxTokens returns default when stored value is negative")
+    func maxTokensNegative() {
+        let defaults = makeTestDefaults()
+        defaults.set(-100, forKey: ClaudeAPIService.maxTokensDefaultsKey)
         let service = ClaudeAPIService(defaults: defaults)
         #expect(service.maxTokens == 4096)
     }

--- a/RSSAppTests/Services/ModelConfigurationValidationTests.swift
+++ b/RSSAppTests/Services/ModelConfigurationValidationTests.swift
@@ -4,14 +4,14 @@ import Testing
 @Suite("ModelValidation")
 struct ModelValidationTests {
 
-    @Test("valid model identifier passes validation")
+    @Test("valid model identifier passes validation and carries trimmed value")
     func validModel() {
-        #expect(ModelValidation.validate("claude-haiku-4-5-20251001") == .valid)
+        #expect(ModelValidation.validate("claude-haiku-4-5-20251001") == .valid("claude-haiku-4-5-20251001"))
     }
 
     @Test("valid model with simple name passes validation")
     func validModelSimple() {
-        #expect(ModelValidation.validate("claude-sonnet-4-6") == .valid)
+        #expect(ModelValidation.validate("claude-sonnet-4-6") == .valid("claude-sonnet-4-6"))
     }
 
     @Test("empty string returns .empty")
@@ -52,26 +52,26 @@ struct ModelValidationTests {
     func claudeHyphenAlone() {
         // Technically starts with "claude-" and all characters valid, so passes client-side.
         // The API will reject it at runtime.
-        #expect(ModelValidation.validate("claude-") == .valid)
+        #expect(ModelValidation.validate("claude-") == .valid("claude-"))
     }
 }
 
 @Suite("MaxTokensValidation")
 struct MaxTokensValidationTests {
 
-    @Test("valid positive integer passes validation")
+    @Test("valid positive integer passes validation and carries parsed value")
     func validNumber() {
-        #expect(MaxTokensValidation.validate("4096") == .valid)
+        #expect(MaxTokensValidation.validate("4096") == .valid(4096))
     }
 
     @Test("1 is valid (minimum)")
     func minimumValue() {
-        #expect(MaxTokensValidation.validate("1") == .valid)
+        #expect(MaxTokensValidation.validate("1") == .valid(1))
     }
 
     @Test("large number is valid")
     func largeNumber() {
-        #expect(MaxTokensValidation.validate("128000") == .valid)
+        #expect(MaxTokensValidation.validate("128000") == .valid(128000))
     }
 
     @Test("empty string returns .empty")


### PR DESCRIPTION
## Summary
- Add user-configurable Claude model identifier and max output tokens fields to the API Settings screen
- Replace hardcoded defaults (`claude-sonnet-4-6` / `1024`) with `claude-haiku-4-5-20251001` / `4096`, stored in UserDefaults
- `ClaudeAPIService` reads values from UserDefaults at call time so changes take effect immediately without app restart
- Inline validation with green checkmark / red indicator feedback for both fields

Closes #85, Closes #90

## Changes
- **ClaudeAPIService.swift** -- Remove hardcoded `model` and `maxTokens` static constants; add UserDefaults-backed computed properties with fallback defaults; accept `UserDefaults` init parameter for testability; add model/maxTokens to sendMessage debug log
- **ModelConfigurationValidator.swift** (new) -- `ModelValidation` and `MaxTokensValidation` enums extracted from view to Services layer; `.valid` cases carry associated values (trimmed String / parsed Int)
- **APIKeySettingsView.swift** -- Add "Model Configuration" section with model text field (validated: must start with `claude-`, lowercase alphanumeric + hyphens) and max tokens numeric field (validated: positive integer, minimum 1); use validation enums with switch for save logic; `.notice` level for persistence, `.debug` for rejected input
- **ClaudeAPIServiceTests.swift** -- Update all tests to use isolated UserDefaults suites with `removePersistentDomain`; add tests for default values, custom values, empty string fallback, zero fallback, negative fallback, and dynamic reading
- **ModelConfigurationValidationTests.swift** -- 18 tests covering both validation enums (valid with associated values, empty, invalid cases); moved from Views/ to Services/
- **ARCHITECTURE.md** -- Update directory structure, component descriptions, file counts, and test coverage table

## Test plan
- [x] Built successfully for iOS 26
- [x] All new/updated tests pass (ClaudeAPIService + validation)
- [x] Full test suite passes (no regressions)
- [ ] Manually verify model and max tokens fields appear in Settings > API Key
- [ ] Verify empty fields show "Will use default" info label
- [ ] Verify invalid input shows red warning indicator
- [ ] Verify valid input shows green checkmark
- [ ] Verify changed model/tokens are used in next Claude API call

🤖 Generated with [Claude Code](https://claude.com/claude-code)