### PR TITLE
fix: Cache Keychain API key presence instead of reading on every body evaluation

### DIFF
--- a/RSSApp/ViewModels/DiscussionViewModel.swift
+++ b/RSSApp/ViewModels/DiscussionViewModel.swift
@@ -12,10 +12,7 @@ final class DiscussionViewModel {
     var currentInput: String = ""
     var isGenerating: Bool = false
     var errorMessage: String?
-
-    var hasAPIKey: Bool {
-        keychainService.hasAPIKey
-    }
+    private(set) var hasAPIKey: Bool = false
 
     private let article: Article
     private let content: ArticleContent
@@ -32,6 +29,12 @@ final class DiscussionViewModel {
         self.content = content
         self.claudeService = claudeService ?? ClaudeAPIService()
         self.keychainService = keychainService ?? KeychainService()
+        self.hasAPIKey = self.keychainService.hasAPIKey
+    }
+
+    /// Re-checks the Keychain for API key presence and updates the cached state.
+    func refreshHasAPIKey() {
+        hasAPIKey = keychainService.hasAPIKey
     }
 
     func sendMessage() async {

--- a/RSSApp/Views/APIKeySettingsView.swift
+++ b/RSSApp/Views/APIKeySettingsView.swift
@@ -7,15 +7,11 @@ struct APIKeySettingsView: View {
     @State private var saveError: String?
     @State private var modelInput: String = ""
     @State private var maxTokensInput: String = ""
+    @State private var hasAPIKey: Bool = false
 
     private static let logger = Logger(category: "APIKeySettingsView")
 
     private let keychainService = KeychainService()
-
-    /// Whether an API key is currently stored in the Keychain.
-    private var hasAPIKey: Bool {
-        keychainService.hasAPIKey
-    }
 
     var body: some View {
         Form {
@@ -49,6 +45,7 @@ struct APIKeySettingsView: View {
                 Button("Remove Key", role: .destructive) {
                     keychainService.deleteAPIKey()
                     keyInput = ""
+                    refreshHasAPIKey()
                 }
                 .disabled(!hasAPIKey)
             }
@@ -58,6 +55,7 @@ struct APIKeySettingsView: View {
         .navigationTitle("API Key")
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
+            refreshHasAPIKey()
             if let existing = keychainService.loadAPIKey() {
                 // Show a placeholder so the user knows a key is set, without revealing it.
                 keyInput = String(repeating: "•", count: min(existing.count, 20))
@@ -149,6 +147,12 @@ struct APIKeySettingsView: View {
         }
     }
 
+    // MARK: - Keychain State
+
+    private func refreshHasAPIKey() {
+        hasAPIKey = keychainService.hasAPIKey
+    }
+
     // MARK: - Persistence
 
     private func saveKey() {
@@ -160,6 +164,7 @@ struct APIKeySettingsView: View {
         do {
             try keychainService.saveAPIKey(trimmed)
             isSaved = true
+            refreshHasAPIKey()
             Self.logger.notice("API key saved to Keychain")
         } catch {
             saveError = "Unable to save your API key to the Keychain. Please try again."

--- a/RSSApp/Views/ArticleDiscussionView.swift
+++ b/RSSApp/Views/ArticleDiscussionView.swift
@@ -30,7 +30,12 @@ struct ArticleDiscussionView: View {
                     Button("Done") { dismiss() }
                 }
             }
-            .sheet(isPresented: $showSettings) {
+            .onAppear {
+                viewModel.refreshHasAPIKey()
+            }
+            .sheet(isPresented: $showSettings, onDismiss: {
+                viewModel.refreshHasAPIKey()
+            }) {
                 NavigationStack {
                     APIKeySettingsView()
                         .toolbar {

--- a/RSSApp/Views/ArticleReaderView.swift
+++ b/RSSApp/Views/ArticleReaderView.swift
@@ -10,13 +10,10 @@ struct ArticleReaderView: View {
     @State private var showSummary = false
     @State private var showAPIKeySettings = false
     @State private var extractionState = ReaderExtractionState()
+    @State private var hasAPIKey: Bool = false
     @Environment(\.dismiss) private var dismiss
 
     private let keychainService = KeychainService()
-
-    private var hasAPIKey: Bool {
-        keychainService.hasAPIKey
-    }
 
     /// Whether content extraction is still in progress (API key present but content not yet available).
     private var isExtracting: Bool {
@@ -52,7 +49,12 @@ struct ArticleReaderView: View {
                         }
                     }
                 }
-                .sheet(isPresented: $showAPIKeySettings) {
+                .onAppear {
+                    refreshHasAPIKey()
+                }
+                .sheet(isPresented: $showAPIKeySettings, onDismiss: {
+                    refreshHasAPIKey()
+                }) {
                     NavigationStack {
                         APIKeySettingsView()
                             .toolbar {
@@ -71,6 +73,12 @@ struct ArticleReaderView: View {
                     )
                 }
         }
+    }
+
+    // MARK: - Keychain State
+
+    private func refreshHasAPIKey() {
+        hasAPIKey = keychainService.hasAPIKey
     }
 
     // MARK: - Content

--- a/RSSAppTests/ViewModels/DiscussionViewModelTests.swift
+++ b/RSSAppTests/ViewModels/DiscussionViewModelTests.swift
@@ -38,12 +38,32 @@ struct DiscussionViewModelTests {
         )
     }
 
-    @Test("hasAPIKey reflects keychain state")
+    @Test("hasAPIKey reflects keychain state at init")
     func hasAPIKey() {
         let withKey = makeVM(hasKey: true)
         let withoutKey = makeVM(hasKey: false)
         #expect(withKey.hasAPIKey == true)
         #expect(withoutKey.hasAPIKey == false)
+    }
+
+    @Test("refreshHasAPIKey picks up keychain changes after init")
+    func refreshHasAPIKey() throws {
+        let keychainMock = MockKeychainService()
+        let vm = DiscussionViewModel(
+            article: TestFixtures.makeArticle(),
+            content: makeContent(),
+            claudeService: MockClaudeAPIService(),
+            keychainService: keychainMock
+        )
+        #expect(vm.hasAPIKey == false)
+
+        try keychainMock.saveAPIKey("sk-test")
+        vm.refreshHasAPIKey()
+        #expect(vm.hasAPIKey == true)
+
+        keychainMock.deleteAPIKey()
+        vm.refreshHasAPIKey()
+        #expect(vm.hasAPIKey == false)
     }
 
     @Test("sendMessage appends user message then assistant message")


### PR DESCRIPTION
## Summary
- Eliminate repeated Keychain I/O by caching `hasAPIKey` as `@State` (views) or stored property (view model) instead of calling `keychainService.hasAPIKey` on every SwiftUI body evaluation
- Keychain is now read only on `.onAppear` and after save/delete operations
- Affects `APIKeySettingsView`, `ArticleReaderView`, `DiscussionViewModel`, and `ArticleDiscussionView`

Fixes #84

## Test plan
- [x] Built successfully for iOS 26
- [x] All existing tests pass
- [x] New `refreshHasAPIKey` test verifies state transitions in `DiscussionViewModel`

🤖 Generated with [Claude Code](https://claude.com/claude-code)