### PR TITLE
fix: Log warning for unexpected Keychain delete errors

### DIFF
--- a/RSSApp/Services/KeychainService.swift
+++ b/RSSApp/Services/KeychainService.swift
@@ -73,6 +73,8 @@ struct KeychainService: KeychainServicing {
         let status = SecItemDelete(query as CFDictionary)
         if status == errSecSuccess {
             Self.logger.notice("Keychain value deleted for account '\(account, privacy: .public)'")
+        } else if status != errSecItemNotFound {
+            Self.logger.warning("Keychain delete failed for account '\(account, privacy: .public)': \(status, privacy: .public)")
         }
     }
 }


### PR DESCRIPTION
## Summary
- `KeychainService.delete(for:)` now logs at `.warning` level when `SecItemDelete` returns a status other than `errSecSuccess` or `errSecItemNotFound`
- Previously, errors like `errSecInteractionNotAllowed`, `errSecParam`, or `errSecInternalError` were silently ignored, making Keychain failures invisible in diagnostics
- `errSecItemNotFound` remains silent (expected path when deleting a non-existent key)

Fixes #98

## Test plan
- [x] Built successfully for iOS 26
- [x] All 446 existing tests pass
- [x] `errSecItemNotFound` remains silent (expected path when deleting before save)
- [x] `errSecSuccess` still logs at `.notice` level

🤖 Generated with [Claude Code](https://claude.com/claude-code)