### PR TITLE
test: Add error propagation test for KeychainServicing.saveAPIKey

### DIFF
--- a/RSSAppTests/Mocks/MockKeychainService.swift
+++ b/RSSAppTests/Mocks/MockKeychainService.swift
@@ -5,8 +5,10 @@ import Foundation
 // single-threaded test contexts where properties are set before the async call.
 final class MockKeychainService: KeychainServicing, @unchecked Sendable {
     private var store: [String: String] = [:]
+    var errorToThrow: (any Error)?
 
     func save(_ value: String, for account: String) throws {
+        if let error = errorToThrow { throw error }
         store[account] = value
     }
 

--- a/RSSAppTests/Services/KeychainServiceTests.swift
+++ b/RSSAppTests/Services/KeychainServiceTests.swift
@@ -83,6 +83,15 @@ struct KeychainAPIKeyConvenienceTests {
         #expect(mock.loadAPIKey() == nil)
     }
 
+    @Test("saveAPIKey propagates errors from save")
+    func saveAPIKeyPropagatesError() {
+        let mock = MockKeychainService()
+        mock.errorToThrow = KeychainError.saveFailed(-25308)
+        #expect(throws: KeychainError.self) {
+            try mock.saveAPIKey("sk-test")
+        }
+    }
+
     @Test("apiKeyAccount returns the expected account identifier")
     func apiKeyAccountValue() {
         #expect(MockKeychainService.apiKeyAccount == "anthropic-api-key")


### PR DESCRIPTION
## Summary
- Add `errorToThrow` property to `MockKeychainService` following existing mock patterns (e.g., `MockFeedStorageService`, `MockFeedPersistenceService`)
- Add `saveAPIKeyPropagatesError` test to `KeychainAPIKeyConvenienceTests` that verifies `KeychainError` propagates through the `saveAPIKey` convenience wrapper
- Guards against regression if `try save(...)` is later accidentally wrapped in `try?`

Fixes #99

## Test plan
- [x] New `saveAPIKeyPropagatesError` test passes
- [x] All 447 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)