### PR TITLE
fix: Log warning for non-errSecItemNotFound Keychain load failures

### DIFF
--- a/RSSApp/Services/KeychainService.swift
+++ b/RSSApp/Services/KeychainService.swift
@@ -60,6 +60,11 @@ struct KeychainService: KeychainServicing {
         let status = SecItemCopyMatching(query as CFDictionary, &result)
 
         guard status == errSecSuccess, let data = result as? Data else {
+            if status != errSecItemNotFound {
+                Self.logger.warning(
+                    "Keychain load failed for account '\(account, privacy: .public)': OSStatus \(status, privacy: .public)"
+                )
+            }
             return nil
         }
         return String(data: data, encoding: .utf8)


### PR DESCRIPTION
## Summary
- Add `.warning`-level logging in `KeychainService.load(for:)` for Keychain errors other than `errSecItemNotFound`
- Previously, `load(for:)` returned `nil` silently for both "no key stored" and genuine Keychain errors (e.g., `errSecAuthFailed`, `errSecInteractionNotAllowed`), making post-mortem diagnosis impossible
- The `errSecItemNotFound` path remains silent to avoid log noise during normal operation

## Changes
- `RSSApp/Services/KeychainService.swift`: Add conditional check after `SecItemCopyMatching` — if the status is not `errSecSuccess` and not `errSecItemNotFound`, log the account and `OSStatus` at `.warning` level

Fixes #106

## Test plan
- [x] Built successfully for iOS 26
- [x] All 449 existing tests pass
- [x] `errSecItemNotFound` path remains silent (no log output for normal "no key" case)
- [x] Non-`errSecItemNotFound` failures now produce a `.warning` log with the account name and OSStatus code

🤖 Generated with [Claude Code](https://claude.com/claude-code)