### PR TITLE
fix: Detect and propagate Claude API SSE error events instead of silently discarding them

### DIFF
--- a/RSSApp/Services/ClaudeAPIService.swift
+++ b/RSSApp/Services/ClaudeAPIService.swift
@@ -9,11 +9,24 @@ protocol ClaudeAPIServicing: Sendable {
     ) async throws -> AsyncThrowingStream<String, Error>
 }
 
-enum ClaudeAPIError: Error, Sendable {
+enum ClaudeAPIError: Error, Sendable, LocalizedError {
     case invalidURL
     case httpError(statusCode: Int)
     case missingAPIKey
     case serverError(message: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            "The API URL is invalid."
+        case .httpError(let statusCode):
+            "The server returned HTTP \(statusCode)."
+        case .missingAPIKey:
+            "No API key configured."
+        case .serverError(let message):
+            message
+        }
+    }
 }
 
 struct ClaudeAPIService: ClaudeAPIServicing {
@@ -135,6 +148,11 @@ struct ClaudeAPIService: ClaudeAPIServicing {
         }
 
         if event.type == "error" {
+            if event.error == nil {
+                Self.logger.warning("Server sent error event with no error object")
+            } else if event.error?.message == nil || event.error?.type == nil {
+                Self.logger.warning("Server error event missing fields — message: \(event.error?.message == nil ? "nil" : "present", privacy: .public), type: \(event.error?.type == nil ? "nil" : "present", privacy: .public)")
+            }
             let errorMessage = event.error?.message ?? "Unknown server error"
             let errorType = event.error?.type ?? "unknown"
             Self.logger.error("Claude API stream error (type=\(errorType, privacy: .public)): \(errorMessage, privacy: .public). Raw: \(json, privacy: .private)")

--- a/RSSAppTests/Services/ClaudeAPIServiceTests.swift
+++ b/RSSAppTests/Services/ClaudeAPIServiceTests.swift
@@ -228,4 +228,30 @@ struct ClaudeAPIServiceTests {
             Issue.record("Unexpected error type: \(error)")
         }
     }
+
+    // MARK: - LocalizedError conformance
+
+    @Test("localizedDescription returns server message for serverError")
+    func localizedDescriptionServerError() {
+        let error = ClaudeAPIError.serverError(message: "Rate limit exceeded")
+        #expect(error.localizedDescription == "Rate limit exceeded")
+    }
+
+    @Test("localizedDescription returns descriptive message for httpError")
+    func localizedDescriptionHTTPError() {
+        let error = ClaudeAPIError.httpError(statusCode: 429)
+        #expect(error.localizedDescription == "The server returned HTTP 429.")
+    }
+
+    @Test("localizedDescription returns descriptive message for missingAPIKey")
+    func localizedDescriptionMissingAPIKey() {
+        let error = ClaudeAPIError.missingAPIKey
+        #expect(error.localizedDescription == "No API key configured.")
+    }
+
+    @Test("localizedDescription returns descriptive message for invalidURL")
+    func localizedDescriptionInvalidURL() {
+        let error = ClaudeAPIError.invalidURL
+        #expect(error.localizedDescription == "The API URL is invalid.")
+    }
 }


### PR DESCRIPTION
## Summary
- Claude API streaming error events (rate limits, overloaded, internal errors) are now detected, logged at `.error` level, and propagated to the caller as `ClaudeAPIError.serverError`
- Previously these events were silently discarded via the `guard event.type == "content_block_delta"` check, causing truncated responses with no user feedback and a misleading "Claude stream finished" info log

Fixes #121

## Changes
- Add `ClaudeAPIError.serverError(message:)` case for server-side stream errors
- Add `ClaudeStreamError` Decodable struct and `error` field on `ClaudeStreamEvent`
- Change `parseSSELine` to `throws`; detect `event.type == "error"` before the `content_block_delta` guard
- Log error type and message at `.error`, raw JSON at `.private` for diagnostics
- The thrown error propagates through the stream continuation to `DiscussionViewModel`, which already displays stream errors inline in the chat bubble
- Update 4 existing `parseSSELine` tests for the new throwing signature
- Add 4 new tests covering error event detection, message extraction, and fallback behavior

## Test plan
- [x] Built successfully for iOS 26
- [x] All 459 tests pass (4 new)
- [x] `parseErrorEvent`: throws `ClaudeAPIError` for `overloaded_error`
- [x] `parseErrorEventMessage`: extracts error message from `rate_limit_error`
- [x] `parseErrorEventNoMessage`: falls back to "Unknown server error" when message absent
- [x] `parseErrorEventNoErrorObject`: falls back when error object absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)