### PR TITLE
test: Add integration test for ClaudeAPIError.serverError propagation to DiscussionViewModel

### DIFF
--- a/RSSAppTests/ViewModels/DiscussionViewModelTests.swift
+++ b/RSSAppTests/ViewModels/DiscussionViewModelTests.swift
@@ -155,6 +155,16 @@ struct DiscussionViewModelTests {
         #expect(vm.messages[1].content.hasPrefix("Error:"))
     }
 
+    @Test("sendMessage surfaces serverError message in assistant bubble")
+    func sendHandlesServerError() async {
+        let vm = makeVM(error: ClaudeAPIError.serverError(message: "Rate limit exceeded"))
+        vm.currentInput = "A question"
+        await vm.sendMessage()
+        #expect(vm.messages.count == 2)
+        #expect(vm.messages[1].role == .assistant)
+        #expect(vm.messages[1].content == "Error: Rate limit exceeded")
+    }
+
     @Test("sendMessage does nothing when input is empty")
     func sendIgnoresEmptyInput() async {
         let vm = makeVM()


### PR DESCRIPTION
## Summary
- Add a test in `DiscussionViewModelTests` that injects `ClaudeAPIError.serverError(message: "Rate limit exceeded")` via `MockClaudeAPIService` and verifies the server's error message surfaces inline in the assistant chat bubble
- Confirms the full error path: `serverError(message:)` -> `LocalizedError` conformance -> `error.localizedDescription` -> `"Error: Rate limit exceeded"` in the assistant message

Fixes #123

## Test plan
- [x] Built successfully for iOS 26
- [x] All 464 tests pass (463 existing + 1 new)
- [x] `sendHandlesServerError`: injects `serverError(message:)`, asserts assistant message content is exactly `"Error: Rate limit exceeded"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)