### PR TITLE
fix: Refresh unread count via onDisappear instead of dead navigationPath onChange

### DIFF
--- a/RSSApp/Views/FeedListView.swift
+++ b/RSSApp/Views/FeedListView.swift
@@ -13,7 +13,6 @@ struct FeedListView: View {
     @State private var navigationPath = NavigationPath()
     @State private var showAddFeed = false
     @State private var feedToEdit: PersistentFeed?
-    @State private var lastViewedFeedID: PersistentFeed.ID?
 
     private let persistence: FeedPersisting
     private let thumbnailService: ArticleThumbnailCaching = ArticleThumbnailService()
@@ -57,7 +56,7 @@ struct FeedListView: View {
                         persistence: persistence,
                         thumbnailService: thumbnailService
                     )
-                    .onAppear { lastViewedFeedID = feedID }
+                    .onDisappear { viewModel.refreshUnreadCount(for: feed) }
                 } else {
                     ContentUnavailableView {
                         Label("Feed Not Found", systemImage: "exclamationmark.triangle")
@@ -84,13 +83,6 @@ struct FeedListView: View {
             }
             .task {
                 viewModel.loadFeeds()
-            }
-            .onChange(of: navigationPath.count) { oldCount, newCount in
-                if newCount < oldCount,
-                   let feedID = lastViewedFeedID,
-                   let feed = viewModel.feeds.first(where: { $0.id == feedID }) {
-                    viewModel.refreshUnreadCount(for: feed)
-                }
             }
     }
 


### PR DESCRIPTION
## Summary
- Fix unread badge not updating when navigating back from a feed's article list in the embedded `FeedListView` (pushed from `HomeView`)
- The previous `onChange(of: navigationPath.count)` handler never fired when embedded because the parent `HomeView` owns the `NavigationStack`
- Replace with `.onDisappear` on the `ArticleListView` inside `navigationDestination`, which fires correctly regardless of which view owns the navigation stack

Fixes #138

## Test plan
- [x] Built successfully for iOS 26
- [x] All existing tests pass
- [ ] Unread badge updates when navigating back from article list in embedded mode (Home > All Feeds > Feed > back)
- [ ] Unread badge updates when navigating back from article list in standalone mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)