### PR TITLE
fix: Add warning log when navigated feed ID is not found in FeedListView

### DIFF
--- a/RSSApp/Views/FeedListView.swift
+++ b/RSSApp/Views/FeedListView.swift
@@ -1,3 +1,4 @@
+import os
 import SwiftUI
 
 /// Typed navigation destination for push navigation to settings.
@@ -9,6 +10,8 @@ enum SettingsDestination: Hashable {
 }
 
 struct FeedListView: View {
+    private static let logger = Logger(category: "FeedListView")
+
     @State private var viewModel: FeedListViewModel
     @State private var navigationPath = NavigationPath()
     @State private var showAddFeed = false
@@ -58,6 +61,7 @@ struct FeedListView: View {
                     )
                     .onDisappear { viewModel.refreshUnreadCount(for: feed) }
                 } else {
+                    let _ = Self.logger.warning("Feed not found for navigated ID: \(feedID)")
                     ContentUnavailableView {
                         Label("Feed Not Found", systemImage: "exclamationmark.triangle")
                     } description: {


### PR DESCRIPTION
## Summary
- Add `.warning` level log in `FeedListView` when a feed ID navigation destination resolves to a feed not present in the view model's feed list
- Follows project logging guidelines: unexpected but recoverable situations should be logged at `.warning` level for post-mortem diagnosis

Fixes #141

## Changes
- Add `import os` and `private static let logger = Logger(category: "FeedListView")` to `FeedListView`
- Add `logger.warning("Feed not found for navigated ID: \(feedID)")` in the else branch of the feed-ID navigation destination
- Uses `let _ = Self.logger.warning(...)` pattern required in `@ViewBuilder` context

## Test plan
- [x] Built successfully for iOS 26
- [x] All existing tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)