### PR TITLE
fix: Add RATIONALE comment for silent icon persistence failure

### DIFF
--- a/RSSApp/ViewModels/FeedListViewModel.swift
+++ b/RSSApp/ViewModels/FeedListViewModel.swift
@@ -376,6 +376,10 @@ final class FeedListViewModel {
         do {
             try persistence.updateFeedIcon(feed, iconURL: iconURL)
         } catch {
+            // RATIONALE: No errorMessage set here. This runs inside a fire-and-forget Task
+            // spawned by refreshAllFeeds(), so setting errorMessage would race with the
+            // post-refresh errorMessage assignments. Icon persistence failure is also cosmetic
+            // and self-healing — the icon is re-resolved and re-cached on the next refresh.
             Self.logger.error("Failed to persist icon URL for '\(feed.title, privacy: .public)': \(error, privacy: .public)")
         }
     }


### PR DESCRIPTION
## Summary
- Annotate the intentionally silent error path in `resolveAndCacheIconIfNeeded` with a `RATIONALE:` comment explaining why `errorMessage` is not set in the catch block
- The method runs inside fire-and-forget `Task` blocks spawned by `refreshAllFeeds()`, so setting `errorMessage` would race with the post-refresh `errorMessage` assignments
- Icon persistence failure is cosmetic and self-healing -- the icon is re-resolved and re-cached on the next refresh

Fixes #148

## Test plan
- [x] All existing tests pass
- [x] No functional behavior change -- comment-only addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)