### PR TITLE
feat: Add pull-to-refresh to HomeView, AllArticlesView, and UnreadArticlesView

### DIFF
--- a/RSSApp/ViewModels/HomeViewModel.swift
+++ b/RSSApp/ViewModels/HomeViewModel.swift
@@ -27,10 +27,11 @@ final class HomeViewModel {
     private let persistence: FeedPersisting
 
     /// Async closure that performs the actual network feed refresh.
-    /// Injected by the parent view to delegate to `FeedListViewModel.refreshAllFeeds()`.
-    private let refreshFeeds: (@Sendable () async -> Void)?
+    /// Returns an error message string on failure, or nil on success.
+    /// Injected by the caller to perform the actual network feed refresh.
+    private let refreshFeeds: (@Sendable () async -> String?)?
 
-    init(persistence: FeedPersisting, refreshFeeds: (@Sendable () async -> Void)? = nil) {
+    init(persistence: FeedPersisting, refreshFeeds: (@Sendable () async -> String?)? = nil) {
         self.persistence = persistence
         self.refreshFeeds = refreshFeeds
     }
@@ -41,8 +42,12 @@ final class HomeViewModel {
 
     // MARK: - Refresh
 
-    /// Triggers a full network refresh of all feeds, then reloads local data.
+    /// Triggers a full network refresh of all feeds.
     /// When no refresh closure is configured, this is a no-op.
+    ///
+    /// This method only performs the network refresh and sets `errorMessage` on failure.
+    /// Callers are responsible for reloading local data afterward (e.g., `loadUnreadCount()`,
+    /// `loadAllArticles()`) so each view reloads exactly what it needs.
     func refreshAllFeeds() async {
         guard let refreshFeeds else {
             Self.logger.debug("refreshAllFeeds() called but no refresh closure configured")
@@ -53,13 +58,17 @@ final class HomeViewModel {
             return
         }
         Self.logger.debug("refreshAllFeeds() starting network refresh")
+        errorMessage = nil
         isRefreshing = true
         defer { isRefreshing = false }
 
-        await refreshFeeds()
-
-        loadUnreadCount()
-        Self.logger.notice("refreshAllFeeds() completed, unread count updated")
+        let refreshError = await refreshFeeds()
+        if let refreshError {
+            errorMessage = refreshError
+            Self.logger.error("refreshAllFeeds() finished with error: \(refreshError, privacy: .public)")
+        } else {
+            Self.logger.notice("refreshAllFeeds() completed successfully")
+        }
     }
 
     func loadUnreadCount() {

--- a/RSSApp/Views/AllArticlesView.swift
+++ b/RSSApp/Views/AllArticlesView.swift
@@ -62,6 +62,7 @@ struct AllArticlesView: View {
         .refreshable {
             await homeViewModel.refreshAllFeeds()
             homeViewModel.loadAllArticles()
+            homeViewModel.loadUnreadCount()
         }
         .task {
             homeViewModel.loadAllArticles()

--- a/RSSApp/Views/HomeView.swift
+++ b/RSSApp/Views/HomeView.swift
@@ -14,6 +14,7 @@ struct HomeView: View {
             persistence: persistence,
             refreshFeeds: { [feedListVM] in
                 await feedListVM.refreshAllFeeds()
+                return await feedListVM.errorMessage
             }
         ))
     }
@@ -28,6 +29,7 @@ struct HomeView: View {
             .listStyle(.plain)
             .refreshable {
                 await viewModel.refreshAllFeeds()
+                viewModel.loadUnreadCount()
             }
             .navigationTitle("Home")
             .navigationDestination(for: HomeGroup.self) { group in

--- a/RSSApp/Views/UnreadArticlesView.swift
+++ b/RSSApp/Views/UnreadArticlesView.swift
@@ -66,6 +66,7 @@ struct UnreadArticlesView: View {
         .refreshable {
             await homeViewModel.refreshAllFeeds()
             homeViewModel.loadUnreadArticles()
+            homeViewModel.loadUnreadCount()
         }
         .task {
             homeViewModel.loadUnreadArticles()

--- a/RSSAppTests/ViewModels/HomeViewModelTests.swift
+++ b/RSSAppTests/ViewModels/HomeViewModelTests.swift
@@ -11,6 +11,15 @@ private actor CallCounter {
     }
 }
 
+/// Sendable toggle for controlling closure behavior across `@Sendable` boundaries in tests.
+private actor FailToggle {
+    private(set) var shouldFail = true
+
+    func setShouldFail(_ value: Bool) {
+        shouldFail = value
+    }
+}
+
 @Suite("HomeViewModel Tests")
 struct HomeViewModelTests {
 
@@ -517,27 +526,23 @@ struct HomeViewModelTests {
 
     // MARK: - Refresh All Feeds
 
-    @Test("refreshAllFeeds calls refresh closure and reloads unread count")
+    @Test("refreshAllFeeds calls refresh closure")
     @MainActor
-    func refreshAllFeedsCallsClosureAndReloadsCount() async {
-        let feed = TestFixtures.makePersistentFeed()
+    func refreshAllFeedsCallsClosure() async {
         let mockPersistence = MockFeedPersistenceService()
-        mockPersistence.feeds = [feed]
-
-        let article = TestFixtures.makePersistentArticle(articleID: "a1", isRead: false)
-        article.feed = feed
-        mockPersistence.articlesByFeedID[feed.id] = [article]
-
         let refreshCallCount = CallCounter()
         let viewModel = HomeViewModel(
             persistence: mockPersistence,
-            refreshFeeds: { await refreshCallCount.increment() }
+            refreshFeeds: {
+                await refreshCallCount.increment()
+                return nil
+            }
         )
 
         await viewModel.refreshAllFeeds()
 
         #expect(await refreshCallCount.value == 1)
-        #expect(viewModel.unreadCount == 1)
+        #expect(viewModel.errorMessage == nil)
     }
 
     @Test("refreshAllFeeds is no-op without refresh closure")
@@ -560,12 +565,49 @@ struct HomeViewModelTests {
 
         let viewModel = HomeViewModel(
             persistence: mockPersistence,
-            refreshFeeds: {}
+            refreshFeeds: { return nil }
         )
 
         #expect(viewModel.isRefreshing == false)
         await viewModel.refreshAllFeeds()
         #expect(viewModel.isRefreshing == false)
+    }
+
+    @Test("refreshAllFeeds sets errorMessage when refresh closure returns error")
+    @MainActor
+    func refreshAllFeedsSetsErrorFromClosure() async {
+        let mockPersistence = MockFeedPersistenceService()
+        let viewModel = HomeViewModel(
+            persistence: mockPersistence,
+            refreshFeeds: { return "2 of 5 feed(s) could not be updated." }
+        )
+
+        await viewModel.refreshAllFeeds()
+
+        #expect(viewModel.errorMessage == "2 of 5 feed(s) could not be updated.")
+        #expect(viewModel.isRefreshing == false)
+    }
+
+    @Test("refreshAllFeeds clears previous errorMessage on success")
+    @MainActor
+    func refreshAllFeedsClearsPreviousError() async {
+        let mockPersistence = MockFeedPersistenceService()
+        let failToggle = FailToggle()
+
+        let viewModel = HomeViewModel(
+            persistence: mockPersistence,
+            refreshFeeds: {
+                return await failToggle.shouldFail ? "Error" : nil
+            }
+        )
+
+        await viewModel.refreshAllFeeds()
+        #expect(viewModel.errorMessage == "Error")
+
+        // Second call succeeds — error should be cleared
+        await failToggle.setShouldFail(false)
+        await viewModel.refreshAllFeeds()
+        #expect(viewModel.errorMessage == nil)
     }
 
     @Test("refreshAllFeeds skips when already refreshing")
@@ -586,6 +628,7 @@ struct HomeViewModelTests {
                 // rejected by the guard before reaching this closure.
                 var iterator = holdStream.makeAsyncIterator()
                 _ = await iterator.next()
+                return nil
             }
         )
 
@@ -607,15 +650,31 @@ struct HomeViewModelTests {
         #expect(await refreshCallCount.value == 1)
     }
 
-    @Test("init without refreshFeeds defaults to nil")
+    @Test("refreshAllFeeds does not call loadUnreadCount — callers are responsible")
     @MainActor
-    func initWithoutRefreshFeedsDefaultsToNil() async {
+    func refreshAllFeedsDoesNotReloadUnreadCount() async {
+        let feed = TestFixtures.makePersistentFeed()
         let mockPersistence = MockFeedPersistenceService()
-        let viewModel = HomeViewModel(persistence: mockPersistence)
+        mockPersistence.feeds = [feed]
 
-        // Should be safe to call — no-op
+        let article = TestFixtures.makePersistentArticle(articleID: "a1", isRead: false)
+        article.feed = feed
+        mockPersistence.articlesByFeedID[feed.id] = [article]
+
+        let viewModel = HomeViewModel(
+            persistence: mockPersistence,
+            refreshFeeds: { return nil }
+        )
+
+        // Unread count starts at 0 (not yet loaded)
+        #expect(viewModel.unreadCount == 0)
         await viewModel.refreshAllFeeds()
-        #expect(viewModel.isRefreshing == false)
+        // refreshAllFeeds does NOT reload unread count — caller must do it
+        #expect(viewModel.unreadCount == 0)
+
+        // Caller explicitly reloads
+        viewModel.loadUnreadCount()
+        #expect(viewModel.unreadCount == 1)
     }
 
     // MARK: - Clear Error


### PR DESCRIPTION
## Summary
- Add pull-to-refresh (`.refreshable`) to `HomeView`, `AllArticlesView`, and `UnreadArticlesView` for consistency with `FeedListView`
- Pull-to-refresh triggers a full network feed refresh via `FeedListViewModel.refreshAllFeeds()`, then reloads local article data and unread counts
- `HomeViewModel` accepts an injectable async refresh closure, keeping it decoupled from `FeedListViewModel` and testable with mocks

Fixes #96

## Changes
- **HomeViewModel**: Add `refreshAllFeeds()` async method, `isRefreshing` state, and injectable `@Sendable` refresh closure parameter
- **HomeView**: Wire `FeedListViewModel.refreshAllFeeds()` as the refresh closure; add `.refreshable` to the Home list
- **AllArticlesView**: Add `.refreshable` that triggers refresh then reloads the article list
- **UnreadArticlesView**: Add `.refreshable` that triggers refresh then reloads the unread list
- **HomeViewModelTests**: Add 5 tests covering refresh invocation, no-op without closure, isRefreshing lifecycle, duplicate refresh guard, and default init

## Design notes
- The refresh closure approach keeps `HomeViewModel` decoupled from `FeedListViewModel` — it only knows it has an async callback, enabling easy mock injection for tests
- The design does not preclude future group-based refresh prioritization (the closure can be swapped for a group-aware implementation later)
- `.refreshable` is placed on the `Group` container in child views, so it applies to the `List` when articles exist but not to the `ContentUnavailableView` empty state (matching `FeedListView` behavior)

## Test plan
- [x] Built successfully for iOS 26
- [x] All existing tests pass (full suite)
- [x] 5 new HomeViewModel refresh tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)