### PR TITLE
fix: Use local list removal instead of full reload when unsaving articles

### DIFF
--- a/RSSApp/ViewModels/HomeViewModel.swift
+++ b/RSSApp/ViewModels/HomeViewModel.swift
@@ -249,6 +249,13 @@ final class HomeViewModel {
         }
     }
 
+    /// Removes an article from the local saved articles list without reloading from persistence.
+    /// Used after unsaving an article in SavedArticlesView to avoid resetting pagination and scroll position.
+    func removeFromSavedList(_ article: PersistentArticle) {
+        savedArticlesList.removeAll { $0.articleID == article.articleID }
+        Self.logger.debug("Removed article '\(article.articleID, privacy: .public)' from saved list (remaining: \(self.savedArticlesList.count, privacy: .public))")
+    }
+
     /// Marks all articles across all feeds as read.
     func markAllAsRead() {
         do {

--- a/RSSApp/Views/SavedArticlesView.swift
+++ b/RSSApp/Views/SavedArticlesView.swift
@@ -46,7 +46,7 @@ struct SavedArticlesView: View {
                     .swipeActions(edge: .trailing) {
                         Button {
                             homeViewModel.toggleSaved(article)
-                            homeViewModel.loadSavedArticles()
+                            homeViewModel.removeFromSavedList(article)
                         } label: {
                             Label("Unsave", systemImage: "bookmark.slash")
                         }

--- a/RSSAppTests/ViewModels/HomeViewModelTests.swift
+++ b/RSSAppTests/ViewModels/HomeViewModelTests.swift
@@ -1273,4 +1273,92 @@ struct HomeViewModelTests {
 
         #expect(viewModel.errorMessage != nil)
     }
+
+    // MARK: - Local List Removal
+
+    @Test("removeFromSavedList removes article from savedArticlesList without reloading")
+    @MainActor
+    func removeFromSavedListRemovesArticle() {
+        let feed = TestFixtures.makePersistentFeed()
+        let mockPersistence = MockFeedPersistenceService()
+        mockPersistence.feeds = [feed]
+
+        let saved1 = TestFixtures.makePersistentArticle(
+            articleID: "s1",
+            isSaved: true,
+            savedDate: Date(timeIntervalSince1970: 1_000)
+        )
+        saved1.feed = feed
+        let saved2 = TestFixtures.makePersistentArticle(
+            articleID: "s2",
+            isSaved: true,
+            savedDate: Date(timeIntervalSince1970: 2_000)
+        )
+        saved2.feed = feed
+        mockPersistence.articlesByFeedID[feed.id] = [saved1, saved2]
+
+        let viewModel = HomeViewModel(persistence: mockPersistence)
+        viewModel.loadSavedArticles()
+        #expect(viewModel.savedArticlesList.count == 2)
+
+        viewModel.removeFromSavedList(saved1)
+
+        #expect(viewModel.savedArticlesList.count == 1)
+        #expect(viewModel.savedArticlesList.first?.articleID == "s2")
+    }
+
+    @Test("removeFromSavedList is no-op when article not in list")
+    @MainActor
+    func removeFromSavedListNoOp() {
+        let feed = TestFixtures.makePersistentFeed()
+        let mockPersistence = MockFeedPersistenceService()
+        mockPersistence.feeds = [feed]
+
+        let saved = TestFixtures.makePersistentArticle(
+            articleID: "s1",
+            isSaved: true,
+            savedDate: Date()
+        )
+        saved.feed = feed
+        mockPersistence.articlesByFeedID[feed.id] = [saved]
+
+        let viewModel = HomeViewModel(persistence: mockPersistence)
+        viewModel.loadSavedArticles()
+        #expect(viewModel.savedArticlesList.count == 1)
+
+        let notInList = TestFixtures.makePersistentArticle(articleID: "other")
+        viewModel.removeFromSavedList(notInList)
+
+        #expect(viewModel.savedArticlesList.count == 1)
+    }
+
+    @Test("removeFromSavedList preserves remaining article order")
+    @MainActor
+    func removeFromSavedListPreservesOrder() {
+        let feed = TestFixtures.makePersistentFeed()
+        let mockPersistence = MockFeedPersistenceService()
+        mockPersistence.feeds = [feed]
+
+        let articles = (0..<5).map { i in
+            let article = TestFixtures.makePersistentArticle(
+                articleID: "s\(i)",
+                isSaved: true,
+                savedDate: Date(timeIntervalSince1970: Double(i) * 1_000)
+            )
+            article.feed = feed
+            return article
+        }
+        mockPersistence.articlesByFeedID[feed.id] = articles
+
+        let viewModel = HomeViewModel(persistence: mockPersistence)
+        viewModel.loadSavedArticles()
+        #expect(viewModel.savedArticlesList.count == 5)
+
+        // Remove the middle article
+        viewModel.removeFromSavedList(articles[2])
+
+        #expect(viewModel.savedArticlesList.count == 4)
+        let remainingIDs = viewModel.savedArticlesList.map(\.articleID)
+        #expect(remainingIDs == ["s4", "s3", "s1", "s0"])
+    }
 }


### PR DESCRIPTION
## Summary
- Unsaving an article in SavedArticlesView now removes it from the local list instead of calling `loadSavedArticles()`, which resets pagination and scrolls back to the top
- Preserves scroll position and pagination state when unsaving articles deep in a long list
- Adds `HomeViewModel.removeFromSavedList(_:)` for local array removal by `articleID`

Fixes #175

## Test plan
- [ ] Built successfully for iOS 26
- [ ] All 3 new HomeViewModel tests pass (removal, no-op, order preservation)
- [ ] All existing tests pass
- [ ] Unsaving an article in SavedArticlesView removes it in-place without scroll reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)