### PR TITLE
feat: Group app badge toggle under a Notifications settings section

### DIFF
--- a/RSSApp/Views/SettingsView.swift
+++ b/RSSApp/Views/SettingsView.swift
@@ -32,26 +32,32 @@ struct SettingsView: View {
 
     var body: some View {
         List {
-            Toggle(isOn: $badgeEnabled) {
-                Label("App Badge", systemImage: "app.badge")
-            }
-            .onChange(of: badgeEnabled) { _, newValue in
-                guard !isRevertingToggle else { return }
-                badgeService.badgeEnabled = newValue
-                Task {
-                    if newValue {
-                        let shouldKeepOn = await homeViewModel.handleBadgeToggleEnabled()
-                        if !shouldKeepOn {
-                            isRevertingToggle = true
-                            badgeEnabled = false
-                            badgeService.badgeEnabled = false
-                            isRevertingToggle = false
-                            showPermissionDeniedAlert = true
+            Section {
+                Toggle(isOn: $badgeEnabled) {
+                    Label("App Badge", systemImage: "app.badge")
+                }
+                .onChange(of: badgeEnabled) { _, newValue in
+                    guard !isRevertingToggle else { return }
+                    badgeService.badgeEnabled = newValue
+                    Task {
+                        if newValue {
+                            let shouldKeepOn = await homeViewModel.handleBadgeToggleEnabled()
+                            if !shouldKeepOn {
+                                isRevertingToggle = true
+                                badgeEnabled = false
+                                badgeService.badgeEnabled = false
+                                isRevertingToggle = false
+                                showPermissionDeniedAlert = true
+                            }
+                        } else {
+                            await badgeService.clearBadge()
                         }
-                    } else {
-                        await badgeService.clearBadge()
                     }
                 }
+            } header: {
+                Text("Notifications")
+            } footer: {
+                Text("Displays the unread article count on the app icon.")
             }
 
             Section {


### PR DESCRIPTION
## Summary
- Wraps the existing app badge toggle in a `Section` with a "Notifications" header and descriptive footer
- Creates visual consistency with the existing "Network" section and establishes a home for future notification-related settings
- No functional changes — toggle behavior, permission flow, alert logic, and `AppBadgeService` integration remain identical

Fixes #205

## Test plan
- [ ] Built successfully for iOS 26
- [ ] All existing tests pass
- [ ] Badge toggle appears under "Notifications" section header with footer text "Displays the unread article count on the app icon."
- [ ] Permission-denied alert still functions when notifications are disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)