### PR TITLE
fix: Harden feed date parsing against timezone-less and exotic inputs

### DIFF
--- a/RSSApp/Services/RSSParsingService.swift
+++ b/RSSApp/Services/RSSParsingService.swift
@@ -506,8 +506,8 @@ private final class RSSParserDelegate: NSObject, XMLParserDelegate, @unchecked S
     ///
     /// Parsing strategy, in order:
     /// 1. `ISO8601DateFormatter` with `.withInternetDateTime` and/or `.withFractionalSeconds`
-    ///    — covers RFC 3339 / Atom formats. This runs first because it's the most constrained
-    ///    parser in the chain and rejects obviously wrong inputs fastest.
+    ///    — covers RFC 3339 / Atom formats. This is the correct format for Atom feeds and
+    ///    the most common format for modern RSS, so it's the common-case fast path.
     /// 2. A list of explicit `DateFormatter` patterns covering RFC 822 / RFC 2822 variants
     ///    and their common real-world deviations (named zones, missing seconds, single-digit
     ///    day, space separator instead of `T`, etc.) — all of which include an explicit zone.
@@ -516,8 +516,11 @@ private final class RSSParserDelegate: NSObject, XMLParserDelegate, @unchecked S
     ///    ambiguous timestamps rather than silently discarding them. The alternative —
     ///    returning `nil` — hides the feed's age entirely in the UI.
     ///
-    /// See [issue #208](https://github.com/nicholas-lonsinger/rss-app/issues/208) for the
-    /// motivating bug report on incorrect article timestamps.
+    /// All successful parses are sanity-checked against a plausible date range. Inputs that
+    /// parse to an impossible absolute moment (e.g., `DateFormatter`'s `yyyy` "year of era"
+    /// accepting `"26"` as year 26 AD) are rejected to prevent corrupt timestamps from
+    /// poisoning cross-feed sorting and retention. See GitHub issue #208 for the motivating
+    /// bug report on incorrect article timestamps.
     private static func parseDate(_ dateString: String) -> Date? {
         let trimmed = dateString.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
@@ -525,22 +528,26 @@ private final class RSSParserDelegate: NSObject, XMLParserDelegate, @unchecked S
         // 1. ISO 8601 / RFC 3339 — most modern feeds use this. Handles `...Z`,
         //    `...+0000`, `...-07:00`, and fractional-second variants.
         if let date = ISO8601Formatters.standard.date(from: trimmed) {
-            return date
+            return sanityChecked(date, input: trimmed, source: "ISO8601")
         }
         if let date = ISO8601Formatters.fractional.date(from: trimmed) {
-            return date
+            return sanityChecked(date, input: trimmed, source: "ISO8601 fractional")
         }
 
         // 2. Explicit-zone DateFormatter patterns (RFC 822 / RFC 2822 and common variants).
         //    Every format here must end in a zone specifier; zone-less formats are handled
         //    in the fallback block below with clearly documented UTC assumption and logging.
+        //    The formatter's `timeZone` is pinned to UTC as defense-in-depth so that any
+        //    format that fails to read a zone from the input (rather than falling through
+        //    to the zoneless block) won't silently inherit the device's local zone.
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "UTC")
 
         for format in Self.zonedDateFormats {
             formatter.dateFormat = format
             if let date = formatter.date(from: trimmed) {
-                return date
+                return sanityChecked(date, input: trimmed, source: "zoned '\(format)'")
             }
         }
 
@@ -548,14 +555,13 @@ private final class RSSParserDelegate: NSObject, XMLParserDelegate, @unchecked S
         //    publisher almost certainly omitted zone information. Interpreting as UTC is
         //    a documented fallback — not a silent guess. We log a warning so these feeds
         //    are visible in diagnostic output.
-        formatter.timeZone = TimeZone(identifier: "UTC")
         for format in Self.zonelessDateFormats {
             formatter.dateFormat = format
             if let date = formatter.date(from: trimmed) {
                 Self.logger.warning(
                     "Feed date '\(trimmed, privacy: .public)' had no timezone; interpreted as UTC (format '\(format, privacy: .public)')"
                 )
-                return date
+                return sanityChecked(date, input: trimmed, source: "zoneless '\(format)'")
             }
         }
 
@@ -565,21 +571,58 @@ private final class RSSParserDelegate: NSObject, XMLParserDelegate, @unchecked S
         return nil
     }
 
-    /// Date formats that include an explicit timezone specifier. Ordered from most-common
-    /// to least-common to minimize average parse cost.
+    /// Plausible-date window used to reject obviously-wrong parse results. The lower bound
+    /// predates RSS itself, so any feed date older than this is almost certainly a parser
+    /// artifact (e.g., `DateFormatter`'s `yyyy` accepting `"26"` as year 26 AD). The upper
+    /// bound allows a day of slop for publishers with clock skew or scheduled posts.
+    private static let minimumPlausibleDate: Date = {
+        var components = DateComponents()
+        components.year = 1990
+        components.month = 1
+        components.day = 1
+        components.timeZone = TimeZone(identifier: "UTC")
+        // RATIONALE: Calendar.date(from:) on a hardcoded valid DateComponents can only
+        // return nil under pathological calendar misconfiguration; distantPast is a safe
+        // fallback that still allows all real-world feeds through.
+        return Calendar(identifier: .gregorian).date(from: components) ?? Date.distantPast
+    }()
+
+    /// Validates that a parsed `Date` falls within a plausible window. Returns the date
+    /// if it passes and `nil` (with a `.warning` log) if it does not.
+    private static func sanityChecked(_ date: Date, input: String, source: String) -> Date? {
+        let upperBound = Date().addingTimeInterval(24 * 60 * 60) // now + 1 day of slop
+        if date < Self.minimumPlausibleDate || date > upperBound {
+            Self.logger.warning(
+                "Rejected out-of-range parsed date \(date, privacy: .public) from input '\(input, privacy: .public)' (source: \(source, privacy: .public))"
+            )
+            return nil
+        }
+        return date
+    }
+
+    /// Date formats that include an explicit timezone specifier. Ordered roughly by
+    /// expected frequency (RFC 822 numeric-offset forms first). The loop tries each format
+    /// in order and stops on the first match, so ordering affects parse cost for
+    /// non-matching inputs but not correctness.
     private static let zonedDateFormats: [String] = [
         // RFC 822 / RFC 2822 with numeric offset (most common in RSS)
         "EEE, dd MMM yyyy HH:mm:ss Z",
         // RFC 822 with named timezone (e.g., "GMT", "EST", "PDT")
         "EEE, dd MMM yyyy HH:mm:ss zzz",
+        // Single-digit day variant (appears in real RFC 822 feeds)
+        "EEE, d MMM yyyy HH:mm:ss Z",
+        "EEE, d MMM yyyy HH:mm:ss zzz",
         // Without weekday (seen in the wild)
         "dd MMM yyyy HH:mm:ss Z",
         "dd MMM yyyy HH:mm:ss zzz",
-        // Without seconds (RFC 822 permits this but it's rare)
+        "d MMM yyyy HH:mm:ss Z",
+        "d MMM yyyy HH:mm:ss zzz",
+        // Without seconds (RFC 2822/5322 permits this; rare but appears in some wire formats)
         "EEE, dd MMM yyyy HH:mm Z",
         "EEE, dd MMM yyyy HH:mm zzz",
-        // ISO 8601 with 'T' separator and numeric zone. Catch-all for ISO 8601-ish feeds
-        // whose exact spacing or fractional-seconds shape trips up ISO8601DateFormatter.
+        // ISO 8601 with 'T' separator and numeric zone. These are defense-in-depth safety
+        // nets for ISO 8601-ish inputs that ISO8601DateFormatter rejects (e.g., unusual
+        // fractional-seconds precision or minor whitespace quirks).
         "yyyy-MM-dd'T'HH:mm:ssZ",
         "yyyy-MM-dd'T'HH:mm:ss.SSSZ",
         // ISO 8601 with space separator instead of 'T' (common in SQL-flavored feeds)

--- a/RSSAppTests/Services/RSSParsingServiceTests.swift
+++ b/RSSAppTests/Services/RSSParsingServiceTests.swift
@@ -491,9 +491,10 @@ struct RSSParsingServiceTests {
 
     @Test("RSS pubDate with colon-separated numeric zone parses to correct absolute UTC moment")
     func rssPubDateColonNumericZone() throws {
-        // RFC 3339-style offset with colon ("-07:00") — not accepted by DateFormatter's Z
-        // specifier but accepted by the RFC 822 Z specifier because DateFormatter is lenient
-        // enough to match. This guards against regressions where the colon form is dropped.
+        // RFC 3339 spells offsets with a colon (`-07:00`). The first parser in `parseDate`
+        // is `ISO8601DateFormatter.withInternetDateTime`, which accepts the colon form;
+        // that's what catches this input in practice. This test guards against regressions
+        // where the colon form is silently dropped from the parser chain.
         let xml = Self.rssXML(pubDate: "Mon, 06 Apr 2026 08:30:00 -07:00")
         let feed = try service.parse(Data(xml.utf8))
 
@@ -553,7 +554,8 @@ struct RSSParsingServiceTests {
 
     @Test("Atom published date with colon-separated zone parses to correct absolute UTC moment")
     func atomPublishedColonZone() throws {
-        // This is the format called out in the original parser comment; ensure it still works.
+        // RFC 3339 / Atom-style colon-separated offset (-07:00) — historically a common
+        // failure mode for naive RSS parsers; this test locks in correct parsing.
         let xml = Self.atomXML(published: "2026-04-06T08:30:00-07:00")
         let feed = try service.parse(Data(xml.utf8))
 
@@ -565,12 +567,15 @@ struct RSSParsingServiceTests {
 
     @Test("Atom published date with fractional seconds and numeric zone parses correctly")
     func atomPublishedFractionalSeconds() throws {
-        let xml = Self.atomXML(published: "2026-04-06T08:30:00.123-07:00")
+        // Non-colon numeric offset (`+0000`) specifically exercises the DateFormatter
+        // `yyyy-MM-dd'T'HH:mm:ss.SSSZ` fallback rather than being caught by
+        // ISO8601Formatters.fractional (which requires a colon in the offset).
+        let xml = Self.atomXML(published: "2026-04-06T08:30:00.123+0000")
         let feed = try service.parse(Data(xml.utf8))
 
         let date = try #require(feed.articles[0].publishedDate)
         let (_, _, _, hr, min, _) = Self.utcComponents(date)
-        #expect(hr == 15)
+        #expect(hr == 8)
         #expect(min == 30)
     }
 
@@ -669,6 +674,49 @@ struct RSSParsingServiceTests {
             )
         )
         #expect(date == expected)
+    }
+
+    @Test("Zoneless input is interpreted as UTC, not the device's local timezone")
+    func zonelessInputIsUTCNotLocal() throws {
+        // Regression guard: a zoneless input must be parsed as an absolute UTC moment,
+        // not as a wall-clock time in the device's local zone. This is the single test
+        // that would catch the dropped-`formatter.timeZone` regression on a non-UTC dev
+        // machine. See issue #208.
+        let xml = Self.rssXML(pubDate: "Mon, 06 Apr 2026 08:30:00")
+        let feed = try service.parse(Data(xml.utf8))
+
+        let date = try #require(feed.articles[0].publishedDate)
+        let expected = try #require(
+            Calendar(identifier: .gregorian).date(
+                from: DateComponents(
+                    timeZone: TimeZone(identifier: "UTC"),
+                    year: 2026, month: 4, day: 6, hour: 8, minute: 30, second: 0
+                )
+            )
+        )
+        #expect(date == expected)
+    }
+
+    @Test("Two-digit year is rejected by the sanity check")
+    func twoDigitYearIsRejected() throws {
+        // `DateFormatter`'s `yyyy` is "year of era" and will happily parse `"26"` as
+        // year 26 AD. The sanity check must reject the resulting date before it poisons
+        // cross-feed sorting and article retention. See issue #208.
+        let xml = Self.rssXML(pubDate: "Mon, 06 Apr 26 08:30:00 +0000")
+        let feed = try service.parse(Data(xml.utf8))
+
+        #expect(feed.articles[0].publishedDate == nil)
+    }
+
+    @Test("Far-future year is rejected by the sanity check")
+    func farFutureDateIsRejected() throws {
+        // A date thousands of years in the future is almost certainly a typo or a
+        // corrupted feed; it should not displace legitimate articles in retention or
+        // sorting. See issue #208.
+        let xml = Self.rssXML(pubDate: "Mon, 06 Apr 9999 08:30:00 +0000")
+        let feed = try service.parse(Data(xml.utf8))
+
+        #expect(feed.articles[0].publishedDate == nil)
     }
 
     // MARK: - XHTML Content


### PR DESCRIPTION
## Summary
- Broaden `RSSParsingService.parseDate` to cover RFC 822 / RFC 2822 / ISO 8601 variants seen in real-world feeds, so article timestamps reflect the true publication moment rather than silently dropping to `nil`
- Add a documented zone-less fallback that interprets the input as UTC and logs a `.warning`, so feeds without timezone info still display an approximate age instead of a blank timestamp in the cross-feed article lists
- Sanity-check every parsed date against a plausible range (`[1990-01-01, now + 1 day]`) so `DateFormatter`'s two-digit-year leniency (e.g., `"26"` parsing as year 26 AD) cannot poison cross-feed sorting or retention
- Lock in the absolute-UTC-moment invariant via direct `Calendar.dateComponents(in: TimeZone)` assertions so future regressions that reintroduce a timezone offset are caught at test time

Addresses #208 (kept open until a real reproducing feed is captured via the new `.warning` logs and a targeted format is added).

## Changes
- `RSSParsingService.parseDate` now runs `ISO8601DateFormatter` first, then a richer list of `DateFormatter` patterns with explicit zones (named zones, missing seconds, missing weekday, single-digit day, space separator variants) with `formatter.timeZone` pinned to UTC as defense-in-depth, and finally a UTC-forced zone-less fallback with a `.warning` log per match
- Add `sanityChecked(_:input:source:)` helper that rejects parsed dates outside `[1990-01-01 UTC, now + 1 day]` and logs a `.warning` with the offending input, called on every successful parse path
- Extract `zonedDateFormats` and `zonelessDateFormats` as named constants for clarity and to make the format list easy to audit and extend
- Add 17 new `RSSParsingServiceTests` cases covering absolute-UTC-moment assertions for PDT, GMT, numeric offsets, colon-separated offsets, fractional seconds (non-colon form that exercises the `DateFormatter` fallback), RFC 822 without weekday/seconds, ISO 8601 with space separator, zone-less fallbacks (RFC 822, ISO 8601, date-only), unparseable inputs, zoneless-is-UTC-not-local regression guard, two-digit-year rejection, and far-future-year rejection

## Notes
- The "7 hours ago" display the issue describes is the observed symptom of a date that was stored as an absolute UTC moment earlier than the true publication time. The most plausible causes are (a) feeds emitting timestamps in an unhandled format and reaching a nil-or-wrong path, or (b) feeds emitting zone-less timestamps that previously returned `nil` and therefore displayed nothing. This PR addresses both: the broader format list eliminates category (a) for common variants, and the zone-less-as-UTC fallback ensures category (b) produces a displayable value with a warning log. If a specific reproducing feed surfaces later with a format still not covered, the `.warning` logs make it easy to identify via `log stream`.
- Review debt filed as follow-up issues: #213 (named non-US timezones), #214 (zoneless-fallback log spam), #215 (per-format test coverage), #216 (DST-boundary tests), #217 (hoist `DateFormatter` allocation).
- The parsing function intentionally stays `private` and is exercised through the public `parse()` entry point, matching the existing test pattern in `RSSParsingServiceTests`.

## Test plan
- [x] All `RSSParsingServiceTests` pass (including the 17 new cases)
- [x] Full `xcodebuild test` suite passes on iPhone 17 Pro simulator
- [ ] Manual verification with real-world feeds that previously showed incorrect timestamps