### PR TITLE
test: Expand AppBadgeService migration edge case coverage

### DIFF
--- a/RSSAppTests/Services/AppBadgeServiceTests.swift
+++ b/RSSAppTests/Services/AppBadgeServiceTests.swift
@@ -81,6 +81,8 @@ struct AppBadgeServiceTests {
         let service = AppBadgeService()
         // New key takes precedence — legacy key is not migrated
         #expect(service.badgeEnabled == false)
+        // Legacy key must be left untouched when the new key already exists.
+        #expect(UserDefaults.standard.string(forKey: Self.legacyBadgeModeKey) == "on")
     }
 
     @Test("Migrates legacy 'unread' badge mode to enabled")
@@ -204,8 +206,8 @@ struct AppBadgeServiceTests {
         #expect(UserDefaults.standard.string(forKey: Self.legacyBadgeModeKey) == nil)
     }
 
-    @Test("Rapid back-to-back instantiation migrates exactly once")
-    func rapidInstantiationMigratesOnce() {
+    @Test("Rapid back-to-back instantiation converges to migrated state")
+    func rapidInstantiationConvergesToMigratedState() {
         UserDefaults.standard.set("unread", forKey: Self.legacyBadgeModeKey)
 
         // Creating many services in rapid succession on the main actor must


### PR DESCRIPTION
## Summary
- Close the review-debt test gap identified in PR #203 by covering the
  remaining edge cases in `AppBadgeService.migrateFromBadgeModeIfNeeded()`.
- Pin current behavior for non-"off" legacy values, absence of both keys,
  numeric legacy payloads, and repeated service initialization.

Closes #204

## Changes
- Migration mapping for additional non-"off" legacy values: `"unread"`,
  `"total"`, an unrecognized future mode, and empty string — all correctly
  map to `enabled = true`.
- New test asserting that when neither the legacy nor the new key is set,
  the service does NOT write the new key, so the getter's "never set" default
  path is preserved (no accidental notification-permission prompt on first launch).
- New test pinning the subtle behavior where a numeric value written under
  the legacy key is coerced to a decimal string by `UserDefaults.string(forKey:)`
  and therefore migrates to `enabled = true`. If the migration is ever changed
  to use `object(forKey:) as? String`, this test will flag it.
- New "new key true overrides legacy off" test covering precedence from the
  opposite direction of the existing `noMigrationWhenNewKeyExists` test.
- Repeated-initialization coverage:
  - Second/third init after migration is a no-op (idempotent).
  - Re-init after a user toggle does NOT revert the user's choice.
  - Creating ten `AppBadgeService` instances in rapid succession on the main
    actor converges on a single migration outcome.

## Test plan
- [x] `xcodebuild test -only-testing:RSSAppTests/AppBadgeServiceTests` — 18/18 passing
- [x] Tests are `@MainActor` and `.serialized`, matching the existing suite
- [x] No production code changes; behavior is unchanged