### PR TITLE
fix: Substitute named non-US timezones before DateFormatter parse

### DIFF
--- a/RSSApp/Services/RSSParsingService.swift
+++ b/RSSApp/Services/RSSParsingService.swift
@@ -603,15 +603,21 @@ private final class RSSParserDelegate: NSObject, XMLParserDelegate, @unchecked S
     /// Only the trailing whitespace-delimited token is examined: feed dates almost
     /// universally place the zone last, and rewriting tokens elsewhere risks corrupting
     /// month names or weekdays that happen to share letters with a zone abbreviation.
+    ///
+    /// The input is trimmed of leading/trailing whitespace and newlines before token
+    /// extraction so trailing-space inputs (e.g., `"...08:30:00 CET "`) still resolve.
+    /// Without this trim, the trailing token would be empty and the lookup would miss,
+    /// causing the input to fall through to the zoneless UTC fallback (off by N hours).
     private static func substituteNamedZone(in input: String) -> String? {
-        guard let separatorIndex = input.lastIndex(where: { $0 == " " }) else {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let separatorIndex = trimmed.lastIndex(where: { $0 == " " }) else {
             return nil
         }
-        let token = input[input.index(after: separatorIndex)...]
+        let token = trimmed[trimmed.index(after: separatorIndex)...]
         guard let offset = Self.namedZoneOffsets[String(token).uppercased()] else {
             return nil
         }
-        return input[..<separatorIndex] + " " + offset
+        return trimmed[..<separatorIndex] + " " + offset
     }
 
     /// Lookup table mapping non-US named timezone abbreviations to their RFC 822 numeric
@@ -686,10 +692,13 @@ private final class RSSParserDelegate: NSObject, XMLParserDelegate, @unchecked S
         "CLT": "-0400",     // Chile Standard Time
         "CLST": "-0300",    // Chile Summer Time
 
-        // Universal aliases not always recognized by DateFormatter
+        // Universal aliases not always recognized by DateFormatter. Bare "Z" is
+        // intentionally omitted: any input ending in `" Z"` is consumed by the
+        // first numeric-zone format (`...HH:mm:ss Z`) in `zonedDateFormats`, since
+        // `DateFormatter`'s `Z` specifier with `en_US_POSIX` accepts the literal
+        // `Z`. The substitution pass would never see it.
         "UT": "+0000",      // Universal Time (RFC 822 alias for UTC)
         "UTC": "+0000",     // Coordinated Universal Time (defense-in-depth)
-        "Z": "+0000",       // Zulu (RFC 3339 alias for UTC)
     ]
 
     /// Plausible-date window used to reject obviously-wrong parse results. The lower bound

--- a/RSSAppTests/Services/RSSParsingServiceTests.swift
+++ b/RSSAppTests/Services/RSSParsingServiceTests.swift
@@ -880,6 +880,60 @@ struct RSSParsingServiceTests {
         #expect(feed.articles[0].publishedDate == nil)
     }
 
+    @Test("RSS pubDate with named CST zone parses as US Central Standard Time, not China")
+    func rssPubDateNamedCSTResolvesToUSCentral() throws {
+        // Regression guard for a load-bearing assumption documented in the
+        // `namedZoneOffsets` doc comment: `DateFormatter`'s `zzz` with `en_US_POSIX`
+        // recognizes "CST" as US Central Standard Time (UTC-6), so the input is
+        // matched by the explicit-zone pass *before* the named-zone substitution
+        // table (which would resolve "CST" to China Standard Time, UTC+8) is ever
+        // consulted. If `en_US_POSIX` ever stops recognizing CST, or if the parse
+        // passes are reordered, US Central feeds would silently shift by 14 hours
+        // — this test must fail in that case.
+        //
+        // 08:30 CST (UTC-6, US Central) = 14:30 UTC. China would be 00:30 UTC.
+        let xml = Self.rssXML(pubDate: "Mon, 06 Apr 2026 08:30:00 CST")
+        let feed = try service.parse(Data(xml.utf8))
+
+        let date = try #require(feed.articles[0].publishedDate)
+        let expected = try Self.utcDate(year: 2026, month: 4, day: 6, hour: 14, minute: 30)
+        #expect(date == expected)
+    }
+
+    @Test("RSS pubDate with trailing whitespace after named zone parses correctly")
+    func rssPubDateNamedZoneTrailingWhitespace() throws {
+        // Regression guard: without input trimming, the trailing token of
+        // `"...08:30:00 CET "` is the empty string after the final space, so the
+        // named-zone lookup misses and the input falls through to the zoneless
+        // UTC fallback — silently producing a date that is 1 hour off. The
+        // `substituteNamedZone` helper trims the input before tokenizing so feeds
+        // emitting trailing whitespace still resolve to the correct moment.
+        //
+        // 08:30 CET (UTC+1) = 07:30 UTC.
+        let xml = Self.rssXML(pubDate: "Mon, 06 Apr 2026 08:30:00 CET ")
+        let feed = try service.parse(Data(xml.utf8))
+
+        let date = try #require(feed.articles[0].publishedDate)
+        let expected = try Self.utcDate(year: 2026, month: 4, day: 6, hour: 7, minute: 30)
+        #expect(date == expected)
+    }
+
+    @Test("RSS pubDate with UT alias parses to UTC")
+    func rssPubDateNamedZoneUTAlias() throws {
+        // RFC 822 explicitly defines "UT" (no trailing C) as an alias for Universal
+        // Time. Whether the substitution pass or `DateFormatter`'s `zzz` matches it
+        // first, the resolved moment must be the literal wall-clock time interpreted
+        // as UTC (08:30 UT = 08:30 UTC). This test documents the current behavior
+        // and acts as a defense-in-depth guard against the table entry being
+        // accidentally removed.
+        let xml = Self.rssXML(pubDate: "Mon, 06 Apr 2026 08:30:00 UT")
+        let feed = try service.parse(Data(xml.utf8))
+
+        let date = try #require(feed.articles[0].publishedDate)
+        let expected = try Self.utcDate(year: 2026, month: 4, day: 6, hour: 8, minute: 30)
+        #expect(date == expected)
+    }
+
     // MARK: - XHTML Content
 
     @Test("Atom XHTML content is reconstructed as HTML")


### PR DESCRIPTION
## Summary
- Feeds emitting European, Asian, Oceanic, or South American timezone abbreviations (`CET`, `CEST`, `BST`, `JST`, `AEST`, `MSK`, `BRT`, ...) previously failed every explicit-zone format because `DateFormatter`'s `zzz` specifier with `en_US_POSIX` only recognizes North American zone names. Affected feeds either fell through to the zoneless UTC fallback (producing a time off by N hours) or returned `nil`.
- This PR rewrites the trailing zone token to its numeric offset before handing the input to `DateFormatter`, restoring correct absolute moments for non-North-American publishers.

Closes #213.

## Changes
- Add `namedZoneOffsets` lookup table in `RSSParsingService` mapping ~30 named zones to RFC 822 numeric offsets, with documented resolutions for ambiguous abbreviations:
  - `IST` → India Standard Time (UTC+5:30)
  - `CST` → China Standard Time (UTC+8) — North American CST is still handled by `DateFormatter`'s `zzz` specifier in the prior pass
  - `BST` → British Summer Time (UTC+1) — Bangladesh Standard Time is far less common in feed payloads
- Extract `parseUsingZonedFormats` helper so the new substitution pass reuses the existing zoned-format loop without duplication.
- Add `substituteNamedZone` preprocessing pass that runs **after** the unsubstituted zoned-format pass fails. This preserves backwards-compatible behavior for North American zones (PDT, EST, GMT, ...) already handled by `DateFormatter` while adding support for the European/Asian/Oceanic/South American set.
- Add 12 new `RSSParsingServiceTests` cases covering CET, CEST, BST, JST, KST, IST, AEST, MSK, BRT, single-digit-day + named zone, lowercase named zone, and an unknown-zone-returns-nil regression guard.

## Test plan
- [x] `xcodebuild test` — full suite passes with no failures or regressions
- [x] All 12 new named-zone tests pass and assert exact UTC moments via `Calendar.dateComponents(in: TimeZone)`
- [x] Existing PDT/GMT/numeric-offset tests still pass (the substitution pass only runs when the prior unsubstituted pass fails)
- [x] Unknown trailing tokens (e.g., `XYZ`) correctly return `nil` instead of silently falling through to the zoneless UTC fallback