### PR TITLE
fix: Demote zoneless-fallback date log to .debug

### DIFF
--- a/RSSApp/Services/RSSParsingService.swift
+++ b/RSSApp/Services/RSSParsingService.swift
@@ -563,12 +563,16 @@ private final class RSSParserDelegate: NSObject, XMLParserDelegate, @unchecked S
 
         // 3. Zone-less fallback. The input doesn't match any explicit-zone format; the
         //    publisher almost certainly omitted zone information. Interpreting as UTC is
-        //    a documented fallback — not a silent guess. We log a warning so these feeds
-        //    are visible in diagnostic output.
+        //    a documented fallback — not a silent guess. Logged at `.debug` so the signal
+        //    is available via `log stream` when investigating a specific feed without
+        //    flooding the persisted log buffer: a feed that always emits zoneless
+        //    timestamps would otherwise produce ~one persisted warning per article per
+        //    refresh cycle, masking other warnings during post-mortem analysis. See
+        //    GitHub issue #214.
         for format in Self.zonelessDateFormats {
             formatter.dateFormat = format
             if let date = formatter.date(from: trimmed) {
-                Self.logger.warning(
+                Self.logger.debug(
                     "Feed date '\(trimmed, privacy: .public)' had no timezone; interpreted as UTC (format '\(format, privacy: .public)')"
                 )
                 return sanityChecked(date, input: trimmed, source: "zoneless '\(format)'")

--- a/RSSAppTests/Services/RSSParsingServiceTests.swift
+++ b/RSSAppTests/Services/RSSParsingServiceTests.swift
@@ -608,7 +608,8 @@ struct RSSParsingServiceTests {
     @Test("Zone-less RFC 822 date is interpreted as UTC (documented fallback)")
     func zonelessRFC822FallsBackToUTC() throws {
         // Previously this input produced `nil`, hiding the article's timestamp from the UI.
-        // The fallback interprets zone-less dates as UTC and logs a warning. See issue #208.
+        // The fallback interprets zone-less dates as UTC and logs at `.debug` (see issue
+        // #208 for the original fix and #214 for the log-level demotion).
         let xml = Self.rssXML(pubDate: "Mon, 06 Apr 2026 08:30:00")
         let feed = try service.parse(Data(xml.utf8))
 


### PR DESCRIPTION
## Summary
- Stop flooding the persisted log buffer with repetitive warnings when a feed always emits zoneless timestamps. A 200-article feed refreshing every ~10 minutes currently produces ~28k persisted `.warning` entries per day, masking other warnings during post-mortem analysis.
- Keep the diagnostic signal available at `.debug` so it can still be captured via `log stream` when investigating a specific feed.

Fixes #214

## Changes
- `RSSParsingService.parseDate`: demote the zoneless-UTC fallback log from `.warning` to `.debug` and expand the surrounding comment to document the rationale and reference issue #214.
- `RSSParsingServiceTests.zonelessRFC822FallsBackToUTC`: update the inline comment so it accurately reflects the new log level and cross-references #208 / #214.

No behavior change — the fallback still interprets zoneless dates as UTC and returns the same `Date` value. Only the log level and comments changed.

## Test plan
- [x] `xcodebuild test -only-testing:RSSAppTests/RSSParsingServiceTests -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` — `** TEST SUCCEEDED **`
- [x] Verified the existing zoneless RFC 822 and ISO 8601 fallback tests still pass end-to-end through `parse(_:)`