### PR TITLE
test: Add per-format date parsing coverage for PR #212 formats

### DIFF
--- a/RSSApp/Services/RSSParsingService.swift
+++ b/RSSApp/Services/RSSParsingService.swift
@@ -746,9 +746,11 @@ private final class RSSParserDelegate: NSObject, XMLParserDelegate, @unchecked S
         // Single-digit day variant (appears in real RFC 822 feeds)
         "EEE, d MMM yyyy HH:mm:ss Z",
         "EEE, d MMM yyyy HH:mm:ss zzz",
-        // Without weekday (seen in the wild)
-        "dd MMM yyyy HH:mm:ss Z",
-        "dd MMM yyyy HH:mm:ss zzz",
+        // Without weekday (seen in the wild). Only the single-digit-day (`d`) variants
+        // are listed: `DateFormatter`'s `d` specifier with `en_US_POSIX` accepts both
+        // one- and two-digit days, so a separate `dd`-prefixed entry would be dead
+        // code (the `d` variant immediately below would already match every input
+        // the `dd` variant could).
         "d MMM yyyy HH:mm:ss Z",
         "d MMM yyyy HH:mm:ss zzz",
         // Without seconds (RFC 2822/5322 permits this; rare but appears in some wire formats)
@@ -759,9 +761,13 @@ private final class RSSParserDelegate: NSObject, XMLParserDelegate, @unchecked S
         // fractional-seconds precision or minor whitespace quirks).
         "yyyy-MM-dd'T'HH:mm:ssZ",
         "yyyy-MM-dd'T'HH:mm:ss.SSSZ",
-        // ISO 8601 with space separator instead of 'T' (common in SQL-flavored feeds)
+        // ISO 8601 with space separator instead of 'T' (common in SQL-flavored feeds).
+        // RATIONALE: there is no separate `"yyyy-MM-dd HH:mm:ss Z"` entry (with a
+        // space before `Z`) because `DateFormatter`'s `Z` specifier with
+        // `en_US_POSIX` tolerates leading whitespace before the offset token, so the
+        // no-space form below already absorbs `"2026-04-06 08:30:00 -0700"` and a
+        // separate spaced variant would be dead code.
         "yyyy-MM-dd HH:mm:ssZ",
-        "yyyy-MM-dd HH:mm:ss Z",
         "yyyy-MM-dd HH:mm:ss zzz",
     ]
 

--- a/RSSAppTests/Services/RSSParsingServiceTests.swift
+++ b/RSSAppTests/Services/RSSParsingServiceTests.swift
@@ -730,60 +730,37 @@ struct RSSParsingServiceTests {
     // entry from the formats list must cause the matching test here to fail.
     // See GitHub issue #215.
 
-    @Test("Zoned format 'dd MMM yyyy HH:mm:ss zzz' is reachable (no weekday, named zone)")
-    func zonedDDMMMYYYYHHmmssNamedZone() throws {
-        // No weekday prefix and a named zone that `DateFormatter`'s `zzz` accepts.
-        // This combination does not match any of the weekday-bearing formats or the
-        // numeric-offset `dd MMM yyyy HH:mm:ss Z` form above it.
-        // 08:30 GMT = 08:30 UTC.
-        let xml = Self.rssXML(pubDate: "06 Apr 2026 08:30:00 GMT")
-        let feed = try service.parse(Data(xml.utf8))
-
-        let date = try #require(feed.articles[0].publishedDate)
-        let expected = try Self.utcDate(year: 2026, month: 4, day: 6, hour: 8, minute: 30)
-        #expect(date == expected)
-    }
-
     @Test("Zoned format 'EEE, dd MMM yyyy HH:mm zzz' is reachable (no seconds, named zone)")
     func zonedEEEDDMMMYYYYHHmmNamedZone() throws {
-        // RFC 2822 permits omitting seconds; pairing that with a named zone reaches
-        // the `EEE, dd MMM yyyy HH:mm zzz` entry specifically. The corresponding
-        // numeric-offset form (`EEE, dd MMM yyyy HH:mm Z`) appears just above it
-        // and will fail against a `GMT` suffix.
-        // 08:30 GMT = 08:30 UTC.
-        let xml = Self.rssXML(pubDate: "Mon, 06 Apr 2026 08:30 GMT")
+        // RFC 2822 permits omitting seconds; pairing that with a named non-`GMT` zone
+        // reaches the `EEE, dd MMM yyyy HH:mm zzz` entry specifically. A `GMT` suffix
+        // would be absorbed by the earlier numeric-offset `EEE, dd MMM yyyy HH:mm Z`
+        // entry, since `DateFormatter`'s `Z` specifier with `en_US_POSIX` accepts the
+        // literal `GMT`. `EST` is rejected by `Z` and accepted by `zzz`, so it
+        // forces the formatter to fall through to the named-zone entry.
+        // 08:30 EST = 13:30 UTC.
+        let xml = Self.rssXML(pubDate: "Mon, 06 Apr 2026 08:30 EST")
         let feed = try service.parse(Data(xml.utf8))
 
         let date = try #require(feed.articles[0].publishedDate)
-        let expected = try Self.utcDate(year: 2026, month: 4, day: 6, hour: 8, minute: 30)
-        #expect(date == expected)
-    }
-
-    @Test("Zoned format 'yyyy-MM-dd HH:mm:ss Z' is reachable (space before numeric offset)")
-    func zonedYYYYMMDDSpaceNumericZone() throws {
-        // `isoSpaceSeparatorZoned` covers `yyyy-MM-dd HH:mm:ssZ` (no space before
-        // the offset). This variant has a space between the time and the offset,
-        // which only `yyyy-MM-dd HH:mm:ss Z` matches.
-        // 08:30 at -0700 = 15:30 UTC.
-        let xml = Self.rssXML(pubDate: "2026-04-06 08:30:00 -0700")
-        let feed = try service.parse(Data(xml.utf8))
-
-        let date = try #require(feed.articles[0].publishedDate)
-        let expected = try Self.utcDate(year: 2026, month: 4, day: 6, hour: 15, minute: 30)
+        let expected = try Self.utcDate(year: 2026, month: 4, day: 6, hour: 13, minute: 30)
         #expect(date == expected)
     }
 
     @Test("Zoned format 'yyyy-MM-dd HH:mm:ss zzz' is reachable (space separator, named zone)")
     func zonedYYYYMMDDSpaceNamedZone() throws {
-        // SQL-flavored space separator combined with a named zone. The named zone
-        // rules out every earlier numeric-offset variant, and the space-before-`T`
-        // form distinguishes it from the ISO 8601 `'T'` variants.
-        // 08:30 GMT = 08:30 UTC.
-        let xml = Self.rssXML(pubDate: "2026-04-06 08:30:00 GMT")
+        // SQL-flavored space separator combined with a named non-`GMT` zone. A `GMT`
+        // suffix would be absorbed by the earlier `yyyy-MM-dd HH:mm:ssZ` entry, since
+        // `DateFormatter`'s `Z` specifier with `en_US_POSIX` accepts the literal
+        // `GMT` and tolerates leading whitespace before the zone token. `EST` is
+        // rejected by `Z` and accepted by `zzz`, so it forces the formatter to fall
+        // through to the named-zone entry.
+        // 08:30 EST = 13:30 UTC.
+        let xml = Self.rssXML(pubDate: "2026-04-06 08:30:00 EST")
         let feed = try service.parse(Data(xml.utf8))
 
         let date = try #require(feed.articles[0].publishedDate)
-        let expected = try Self.utcDate(year: 2026, month: 4, day: 6, hour: 8, minute: 30)
+        let expected = try Self.utcDate(year: 2026, month: 4, day: 6, hour: 13, minute: 30)
         #expect(date == expected)
     }
 
@@ -822,20 +799,24 @@ struct RSSParsingServiceTests {
         let feed = try service.parse(Data(xml.utf8))
 
         let date = try #require(feed.articles[0].publishedDate)
-        let (y, mo, d, hr, mi, _) = Self.utcComponents(date)
+        let (y, mo, d, hr, mi, s) = Self.utcComponents(date)
         #expect(y == 2026)
         #expect(mo == 4)
         #expect(d == 6)
         #expect(hr == 8)
         #expect(mi == 30)
+        // Asserting `s == 0` catches a regression where the formatter mis-reads the
+        // fractional component into the seconds slot (e.g., interpreting `.123` such
+        // that the resulting `Date` lands on `08:30:30.something`).
+        #expect(s == 0)
     }
 
     @Test("Zoneless format 'yyyy-MM-dd HH:mm:ss' is reachable (space separator, no zone)")
     func zonelessYYYYMMDDSpace() throws {
         // SQL-flavored space separator without a zone. Distinguishes this entry
-        // from the zone-bearing `yyyy-MM-dd HH:mm:ssZ` / `yyyy-MM-dd HH:mm:ss Z`
-        // / `yyyy-MM-dd HH:mm:ss zzz` zoned formats and from the ISO 8601 `'T'`
-        // zoneless formats that come earlier in the zoneless list.
+        // from the zone-bearing `yyyy-MM-dd HH:mm:ssZ` / `yyyy-MM-dd HH:mm:ss zzz`
+        // zoned formats and from the ISO 8601 `'T'` zoneless formats that come
+        // earlier in the zoneless list.
         let xml = Self.rssXML(pubDate: "2026-04-06 08:30:00")
         let feed = try service.parse(Data(xml.utf8))
 


### PR DESCRIPTION
## Summary
- Adds a dedicated test per `zonedDateFormats` / `zonelessDateFormats` entry introduced in PR #212 that was not yet individually covered, so a future maintainer cannot silently remove one without a test failure flagging the regression.
- Empirical analysis during review revealed three of the format entries were dead code (every input they could match was already absorbed by an earlier entry); they have been removed alongside their would-be tests with `RATIONALE:` comments at the deletion sites.

Closes #215.

## Changes
- New `// MARK: - Date Parsing (Per-Format Coverage)` section in `RSSParsingServiceTests` with six new `@Test` functions exercising:
  - Zoned: `EEE, dd MMM yyyy HH:mm zzz`, `yyyy-MM-dd HH:mm:ss zzz`
  - Zoneless: `EEE, dd MMM yyyy HH:mm`, `dd MMM yyyy HH:mm:ss`, `yyyy-MM-dd'T'HH:mm:ss.SSS`, `yyyy-MM-dd HH:mm:ss`
- Each remaining input is crafted so every earlier entry in the parse chain (and `ISO8601DateFormatter`) fails to match, forcing the parser to reach the specific entry under test. The two zoned-`zzz` tests use `EST` rather than `GMT` because `DateFormatter`'s `Z` specifier with `en_US_POSIX` accepts the literal `GMT` (and tolerates leading whitespace), so a `GMT`-suffixed input would be silently absorbed by the earlier numeric-offset entry.
- Each assertion compares the absolute UTC moment via the existing `utcDate` / `utcComponents` helpers so the result is independent of the runner's local timezone.
- The `zonelessYYYYMMDDTHHmmssFractional` test now also asserts `s == 0`, catching a regression where the formatter would mis-read the fractional component into the seconds slot.
- Dead-code removal in `RSSParsingService.swift`:
  - `dd MMM yyyy HH:mm:ss Z` and `dd MMM yyyy HH:mm:ss zzz` — `DateFormatter`'s `d` specifier with `en_US_POSIX` accepts both one- and two-digit days, so the single-digit `d MMM ...` variants further down already match every input the `dd MMM ...` variants could.
  - `yyyy-MM-dd HH:mm:ss Z` (with a space before `Z`) — `Z` tolerates leading whitespace before the offset token, so `yyyy-MM-dd HH:mm:ssZ` (no space) already absorbs the same inputs.
- Each deletion is accompanied by a `RATIONALE:` comment at the surviving entry so a future contributor reading the format list understands why the analogous variant is intentionally absent.

## Test plan
- [x] `xcodebuild test` passes in the final clean state
- [x] Empirically verified each remaining EST-substituted test fails when its targeted format entry is removed and only that test fails (confirming it actually exercises its claimed format)
- [x] Empirically verified that removing the three deleted dead-code entries causes no test failures (confirming they were unreachable)