### PR TITLE
fix: Scale FeedIconView with Dynamic Type

### DIFF
--- a/RSSApp/Views/FeedIconView.swift
+++ b/RSSApp/Views/FeedIconView.swift
@@ -3,28 +3,16 @@ import SwiftUI
 struct FeedIconView: View {
 
     enum Style {
-        /// 32pt square with a tertiary-fill background and globe placeholder while loading.
-        /// Used by `FeedRowView` (the row used in `FeedListView`).
+        /// 32pt square (at default Dynamic Type) with a tertiary-fill background and globe
+        /// placeholder while loading. Scales relative to `.headline` so it tracks the adjacent
+        /// feed title in `FeedRowView`. Used by `FeedRowView` (the row used in `FeedListView`).
         case standard
-        /// 14pt square with no background and no placeholder — when no cached icon is available
-        /// the view still occupies its 14pt frame but renders no visible chrome, so surrounding
-        /// text sits flush against an empty slot rather than a globe glyph. Used inline with
-        /// `.caption`-sized text in cross-feed article rows.
+        /// 14pt square (at default Dynamic Type) with no background and no placeholder — when
+        /// no cached icon is available the view still occupies its frame but renders no visible
+        /// chrome, so surrounding text sits flush against an empty slot rather than a globe
+        /// glyph. Scales relative to `.caption` so it tracks the adjacent feed name in
+        /// cross-feed article rows.
         case inline
-
-        fileprivate var iconSize: CGFloat {
-            switch self {
-            case .standard: return 32
-            case .inline: return 14
-            }
-        }
-
-        fileprivate var cornerRadius: CGFloat {
-            switch self {
-            case .standard: return 6
-            case .inline: return 3
-            }
-        }
 
         fileprivate var showsPlaceholder: Bool {
             switch self {
@@ -43,6 +31,29 @@ struct FeedIconView: View {
 
     @State private var iconImage: UIImage?
 
+    // RATIONALE: @ScaledMetric must live on the view (not the Style enum) because property
+    // wrappers require stored properties on a DynamicProperty-conforming type. Both sizes are
+    // declared up front and the body selects one based on `style` — unused metrics are cheap
+    // and this keeps the declarations co-located with their `relativeTo:` text styles.
+    @ScaledMetric(relativeTo: .headline) private var standardIconSize: CGFloat = 32
+    @ScaledMetric(relativeTo: .caption) private var inlineIconSize: CGFloat = 14
+
+    private var iconSize: CGFloat {
+        switch style {
+        case .standard: return standardIconSize
+        case .inline: return inlineIconSize
+        }
+    }
+
+    /// Corner radius scales with the icon so the rounded-rect proportions hold at all
+    /// Dynamic Type sizes (standard: 32pt → 6pt radius, inline: 14pt → 3pt radius).
+    private var cornerRadius: CGFloat {
+        switch style {
+        case .standard: return iconSize * (6.0 / 32.0)
+        case .inline: return iconSize * (3.0 / 14.0)
+        }
+    }
+
     var body: some View {
         ZStack {
             // RATIONALE: Color.clear is an always-present base so the ZStack has concrete
@@ -53,7 +64,7 @@ struct FeedIconView: View {
             Color.clear
 
             if style.showsPlaceholder {
-                RoundedRectangle(cornerRadius: style.cornerRadius)
+                RoundedRectangle(cornerRadius: cornerRadius)
                     .fill(Color(.tertiarySystemFill))
             }
 
@@ -61,13 +72,13 @@ struct FeedIconView: View {
                 Image(uiImage: iconImage)
                     .resizable()
                     .aspectRatio(contentMode: .fit)
-                    .clipShape(RoundedRectangle(cornerRadius: style.cornerRadius))
+                    .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
             } else if style.showsPlaceholder {
                 Image(systemName: "globe")
                     .foregroundStyle(.secondary)
             }
         }
-        .frame(width: style.iconSize, height: style.iconSize)
+        .frame(width: iconSize, height: iconSize)
         .task(id: iconURL) {
             // RATIONALE: Delegates decode + visibility validation + delete-on-corrupt
             // to FeedIconResolving so the cache-validity invariant is enforced once at


### PR DESCRIPTION
## Summary
- Both `FeedIconView` styles now scale with Dynamic Type, so the icon tracks the adjacent feed title/name at all accessibility text sizes.
- At smallest text sizes the icon no longer appears oversized, and at accessibility sizes it no longer appears undersized relative to its label.

Closes #224

## Changes
- Replaced `Style.iconSize` / `Style.cornerRadius` static values with `@ScaledMetric` properties on `FeedIconView`:
  - `.standard`: 32pt relative to `.headline` (adjacent to the feed title in `FeedRowView`)
  - `.inline`: 14pt relative to `.caption` (adjacent to the feed name in `CrossFeedArticleRowView`)
- `cornerRadius` is now computed proportionally from the scaled `iconSize` so the rounded-rect shape holds at all Dynamic Type sizes.
- Updated `Style` doc comments to document the `relativeTo:` text style each case scales against.
- Added a `RATIONALE:` comment explaining why `@ScaledMetric` lives on the view rather than on the `Style` enum (property wrappers require stored properties on a `DynamicProperty`-conforming type).

## Test plan
- [x] Built successfully for iOS 26 (iPhone 17 Pro simulator)
- [x] Full test suite passes
- [ ] Manually verify icon scales with Dynamic Type at xSmall, default, XXXL, and AX5 in both `FeedListView` (standard) and All/Unread/Saved Articles (inline)