### PR TITLE
fix: Treat og:image UTF-8 decode failure as permanent

### DIFF
--- a/RSSApp/Services/ArticleThumbnailService.swift
+++ b/RSSApp/Services/ArticleThumbnailService.swift
@@ -259,10 +259,16 @@ struct ArticleThumbnailService: ArticleThumbnailCaching {
                 if collected.count >= Self.htmlHeadMaxBytes { break }
             }
 
-            guard let html = String(data: collected, encoding: .utf8) else {
-                Self.logger.warning("Article page response is not valid UTF-8 from \(articleLink.absoluteString, privacy: .public)")
-                return .fetchFailed
-            }
+            // RATIONALE: Decode tolerantly with `String(decoding:as:)` rather than the
+            // failable `String(data:encoding:.utf8)`. The 50 KB head slice frequently
+            // cuts through a multi-byte UTF-8 character at the boundary, which makes
+            // strict decoding fail on otherwise-valid pages. Substituting replacement
+            // characters for invalid bytes lets the og:image extractor still find the
+            // tag (which is virtually always pure ASCII). If the page is genuinely
+            // non-UTF-8, the regex will simply fail to match and we fall through to
+            // `.notFound` — a permanent classification — so the prefetcher does not
+            // burn retry budget on a request that can never succeed.
+            let html = String(decoding: collected, as: UTF8.self)
 
             if let ogURL = HTMLUtilities.extractOGImageURL(from: html, baseURL: articleLink) {
                 return .found(ogURL)

--- a/RSSAppTests/Mocks/MockHTMLURLSessionProvider.swift
+++ b/RSSAppTests/Mocks/MockHTMLURLSessionProvider.swift
@@ -15,8 +15,16 @@ import Foundation
 final class MockHTMLURLSessionProvider: URLSessionBytesProviding, @unchecked Sendable {
 
     /// HTML body returned when the response status is 2xx. Ignored for non-2xx
-    /// codes since the service short-circuits before reading bytes.
+    /// codes since the service short-circuits before reading bytes. Also ignored
+    /// when `rawPayload` is set, which takes precedence to allow raw byte fixtures
+    /// (e.g. invalid UTF-8 sequences) that cannot be expressed as a Swift String.
     var htmlBody: String = ""
+
+    /// Raw payload bytes returned when the response status is 2xx. When set,
+    /// overrides `htmlBody`. Use this to drive the UTF-8 decode paths in
+    /// `resolveOGImage` with byte sequences that contain invalid UTF-8 (e.g. a
+    /// 50 KB head slice that cuts through a multi-byte character at the boundary).
+    var rawPayload: Data?
 
     /// HTTP status code for the mock response (default 200).
     var statusCode: Int = 200
@@ -32,7 +40,7 @@ final class MockHTMLURLSessionProvider: URLSessionBytesProviding, @unchecked Sen
 
         MockHTMLURLProtocol.store(
             requestID: requestID,
-            payload: Data(htmlBody.utf8),
+            payload: rawPayload ?? Data(htmlBody.utf8),
             statusCode: statusCode,
             useNonHTTPResponse: useNonHTTPResponse
         )

--- a/RSSAppTests/Services/ArticleThumbnailServiceTests.swift
+++ b/RSSAppTests/Services/ArticleThumbnailServiceTests.swift
@@ -433,6 +433,107 @@ struct ArticleThumbnailServiceTests {
         #expect(result == .found(URL(string: "https://example.com/images/hero.jpg")!))
     }
 
+    // MARK: - resolveOGImage UTF-8 Decoding
+    //
+    // Regression coverage for issue #230: invalid UTF-8 byte sequences (most
+    // commonly caused by the 50 KB head slice cutting through a multi-byte
+    // character at the boundary) must NOT be classified as `.fetchFailed`,
+    // since retrying the same fetch will hit the same problem. The service
+    // now decodes tolerantly via `String(decoding:as:)`, which substitutes
+    // replacement characters for invalid bytes — letting the og:image
+    // extractor still find the (virtually always ASCII) meta tag — and
+    // returns `.notFound` (permanent) when no tag is present so the
+    // prefetcher stops re-fetching.
+
+    @Test("resolveOGImage extracts og:image from page with invalid UTF-8 in unrelated bytes")
+    func resolveOGImageHandlesInvalidUTF8WithValidOGImage() async throws {
+        // Build a payload that contains a valid og:image meta tag followed by
+        // a stray invalid UTF-8 byte (0xFF is never valid in UTF-8). Strict
+        // decoding would return nil and the old code would map this to
+        // `.fetchFailed`; the tolerant decoder substitutes a replacement
+        // character and the regex still matches the og:image tag.
+        var payload = Data("""
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <meta property="og:image" content="https://cdn.example.com/hero.jpg">
+        </head>
+        <body>
+        """.utf8)
+        payload.append(0xFF) // Invalid UTF-8 byte
+        payload.append(contentsOf: Data("</body></html>".utf8))
+
+        let mockSession = MockHTMLURLSessionProvider()
+        mockSession.statusCode = 200
+        mockSession.rawPayload = payload
+        let service = ArticleThumbnailService(session: mockSession)
+        let articleLink = URL(string: "https://example.com/article-invalid-utf8")!
+
+        let result = try await service.resolveOGImage(from: articleLink)
+
+        #expect(result == .found(URL(string: "https://cdn.example.com/hero.jpg")!))
+    }
+
+    @Test("resolveOGImage extracts og:image when payload ends mid multi-byte character")
+    func resolveOGImageHandlesTruncatedMultiByteCharacter() async throws {
+        // Simulate the head slice cutting through a multi-byte UTF-8 character
+        // at the 50 KB boundary. The og:image tag is fully decoded earlier in
+        // the buffer; only the trailing bytes are truncated. The previous
+        // strict-decoding implementation rejected the entire payload as invalid
+        // UTF-8, but the tolerant decoder lets the extractor proceed.
+        var payload = Data("""
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <meta property="og:image" content="https://cdn.example.com/hero.jpg">
+            <title>Café story
+        """.utf8)
+        // The "é" in "Café" above is U+00E9, encoded in UTF-8 as 0xC3 0xA9.
+        // Append a lone leading byte of a multi-byte sequence to simulate
+        // truncation in the middle of a character.
+        payload.append(0xC3)
+
+        let mockSession = MockHTMLURLSessionProvider()
+        mockSession.statusCode = 200
+        mockSession.rawPayload = payload
+        let service = ArticleThumbnailService(session: mockSession)
+        let articleLink = URL(string: "https://example.com/article-truncated")!
+
+        let result = try await service.resolveOGImage(from: articleLink)
+
+        #expect(result == .found(URL(string: "https://cdn.example.com/hero.jpg")!))
+    }
+
+    @Test("resolveOGImage returns .notFound (not .fetchFailed) when invalid UTF-8 page has no og:image")
+    func resolveOGImageReturnsNotFoundForInvalidUTF8WithoutOGImage() async throws {
+        // A page with invalid UTF-8 bytes and no og:image meta tag must map
+        // to `.notFound` (permanent) so the prefetcher does not retry forever.
+        // Pre-fix, this would have hit the strict-decode failure branch and
+        // returned `.fetchFailed`, burning retry budget on a request that
+        // can never succeed.
+        var payload = Data("""
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <title>No og:image here</title>
+        </head>
+        <body>Hello
+        """.utf8)
+        payload.append(0xFF) // Invalid UTF-8 byte
+        payload.append(0xFE)
+        payload.append(contentsOf: Data("</body></html>".utf8))
+
+        let mockSession = MockHTMLURLSessionProvider()
+        mockSession.statusCode = 200
+        mockSession.rawPayload = payload
+        let service = ArticleThumbnailService(session: mockSession)
+        let articleLink = URL(string: "https://example.com/article-invalid-no-og")!
+
+        let result = try await service.resolveOGImage(from: articleLink)
+
+        #expect(result == .notFound)
+    }
+
     @Test("resolveOGImage maps non-HTTPURLResponse to .fetchFailed via -1 sentinel")
     func resolveOGImageNonHTTPResponseReturnsFetchFailed() async throws {
         // Issue #229 explicitly called out the non-HTTPURLResponse → .fetchFailed


### PR DESCRIPTION
## Summary
- Fixes #230. `resolveOGImage(from:)` previously returned `.fetchFailed` when the 50 KB head slice of an article page could not be UTF-8 decoded, which the prefetcher treats as transient and retries. The most common cause is the slice cutting through a multi-byte character at the boundary, so retrying the same fetch hits the same problem and burns retry budget on a request that can never succeed.
- Decode tolerantly with `String(decoding:as:UTF8.self)` so the og:image extractor still gets a chance at the well-formed portion. The og:image meta tag is virtually always pure ASCII, so this lets pages with a truncated trailing character (or stray non-UTF-8 bytes elsewhere) be resolved correctly. If no og:image is found we fall through to the existing `.notFound` (permanent) path so the prefetcher stops retrying.

## Changes
- `ArticleThumbnailService.resolveOGImage(from:)`: replace failable `String(data:encoding:.utf8)` with `String(decoding:as:UTF8.self)` and drop the now-unreachable `.fetchFailed` return. Added a `RATIONALE:` comment explaining the tolerant-decode choice.
- `MockHTMLURLSessionProvider`: add a `rawPayload: Data?` override so tests can drive the mock with byte sequences that aren't expressible as Swift `String`s (e.g. invalid UTF-8 bytes, truncated multi-byte characters).
- `ArticleThumbnailServiceTests`: add three regression tests covering (1) a page with a valid og:image and stray invalid UTF-8 byte, (2) a page truncated mid multi-byte character, and (3) an invalid-UTF-8 page with no og:image returning `.notFound`.

## Test plan
- [x] `xcodebuild test` passes (all suites green)
- [x] New tests `resolveOGImageHandlesInvalidUTF8WithValidOGImage`, `resolveOGImageHandlesTruncatedMultiByteCharacter`, and `resolveOGImageReturnsNotFoundForInvalidUTF8WithoutOGImage` pass
- [x] Existing `resolveOGImage` HTTP classification tests still pass

Closes #230