### PR TITLE
test: Pin hoisted DateFormatter invariant against post-init mutation

### DIFF
--- a/RSSApp/Services/RSSParsingService.swift
+++ b/RSSApp/Services/RSSParsingService.swift
@@ -12,6 +12,44 @@ struct RSSParsingService: Sendable {
 
     static let snippetMaxLength = 200
 
+    // MARK: - Test Accessors
+    //
+    // These accessors expose the private `RSSParserDelegate.HoistedDateFormatters` and
+    // `RSSParserDelegate.ISO8601Formatters` enums to `@testable` test code so the
+    // "never mutated after init" invariant that justifies their `nonisolated(unsafe)`
+    // declaration can be pinned down by unit tests. See GitHub issue #242 and the
+    // `RATIONALE:` comments on the underlying enums for why the invariant matters.
+    //
+    // These are only meant to be consumed by tests. Production code inside
+    // `RSSParserDelegate` keeps using the private nested enums directly. Exposing them
+    // via accessors rather than relaxing the access level on the enums themselves
+    // preserves the invariant that no code outside this file can reach for a raw
+    // `DateFormatter` reference accidentally.
+
+    /// Pre-built zoned `DateFormatter` entries used by `parseDate`. Exposed for
+    /// invariant tests; do not mutate.
+    static var hoistedZonedFormattersForTesting: [(format: String, formatter: DateFormatter)] {
+        RSSParserDelegate.HoistedDateFormatters.zoned
+    }
+
+    /// Pre-built zoneless `DateFormatter` entries used by `parseDate`. Exposed for
+    /// invariant tests; do not mutate.
+    static var hoistedZonelessFormattersForTesting: [(format: String, formatter: DateFormatter)] {
+        RSSParserDelegate.HoistedDateFormatters.zoneless
+    }
+
+    /// The standard (non-fractional) `ISO8601DateFormatter` used by `parseDate`. Exposed
+    /// for invariant tests; do not mutate.
+    static var iso8601StandardFormatterForTesting: ISO8601DateFormatter {
+        RSSParserDelegate.ISO8601Formatters.standard
+    }
+
+    /// The fractional-second `ISO8601DateFormatter` used by `parseDate`. Exposed for
+    /// invariant tests; do not mutate.
+    static var iso8601FractionalFormatterForTesting: ISO8601DateFormatter {
+        RSSParserDelegate.ISO8601Formatters.fractional
+    }
+
     func parse(_ data: Data) throws -> RSSFeed {
         Self.logger.debug("parse() called with \(data.count, privacy: .public) bytes")
 
@@ -735,8 +773,10 @@ private final class RSSParserDelegate: NSObject, XMLParserDelegate, @unchecked S
     // Pre-building one formatter per format also eliminates the shared-mutable-state
     // hazard of a single formatter with an in-loop `dateFormat` assignment, so the
     // parser is safe to invoke concurrently from multiple feed refreshes. See GitHub
-    // issue #217.
-    private enum HoistedDateFormatters {
+    // issue #217. The invariant is pinned down by `RSSParsingServiceTests` via the
+    // `hoistedZonedFormattersForTesting` / `hoistedZonelessFormattersForTesting`
+    // accessors on `RSSParsingService` — see GitHub issue #242.
+    fileprivate enum HoistedDateFormatters {
         /// Date formats that include an explicit timezone specifier, each paired with a
         /// pre-configured `DateFormatter`. Ordered roughly by expected frequency (RFC
         /// 822 numeric-offset forms first). `parseUsingZonedFormats` tries each entry in
@@ -811,8 +851,11 @@ private final class RSSParserDelegate: NSObject, XMLParserDelegate, @unchecked S
     }
 
     // RATIONALE: nonisolated(unsafe) is safe because these formatters are initialized
-    // once via static let and never mutated after initialization — only date(from:) is called.
-    private enum ISO8601Formatters {
+    // once via static let and never mutated after initialization — only date(from:) is
+    // called. The invariant is pinned down by `RSSParsingServiceTests` via the
+    // `iso8601StandardFormatterForTesting` / `iso8601FractionalFormatterForTesting`
+    // accessors on `RSSParsingService` — see GitHub issue #242.
+    fileprivate enum ISO8601Formatters {
         nonisolated(unsafe) static let standard: ISO8601DateFormatter = {
             let formatter = ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime]

--- a/RSSAppTests/Services/RSSParsingServiceTests.swift
+++ b/RSSAppTests/Services/RSSParsingServiceTests.swift
@@ -1812,4 +1812,182 @@ struct RSSParsingServiceTests {
         #expect(snippet.count <= RSSParsingService.snippetMaxLength + 1) // +1 for ellipsis
         #expect(snippet.hasSuffix("…"))
     }
+
+    // MARK: - Hoisted DateFormatter Invariants
+    //
+    // `RSSParsingService` stores pre-built `DateFormatter` and `ISO8601DateFormatter`
+    // instances in `nonisolated(unsafe) static let` arrays to avoid per-call allocation
+    // (see PR #241, issue #217). The `nonisolated(unsafe)` guarantee relies on those
+    // formatters being initialized once and never mutated afterwards — only
+    // `date(from:)` may be called on them. A future edit that adds a stray
+    // `formatter.dateFormat = ...` or `formatter.timeZone = ...` would silently
+    // re-introduce a shared-mutable-state data race.
+    //
+    // These tests pin the invariant down so such a regression fails the suite rather
+    // than hiding until a concurrent refresh corrupts parsed dates. Each test captures
+    // the expected static configuration, then exercises every formatter through the
+    // public `parse()` entry point by feeding it matching pubDate strings, and finally
+    // re-asserts the configuration to prove `parseDate` did not mutate the shared
+    // instance on its way through.
+
+    /// Expected invariants for every hoisted `DateFormatter`: its stored `dateFormat`
+    /// matches the tuple's format string, its locale is pinned to `en_US_POSIX`, and
+    /// its timezone is pinned to the zero-offset zone that the production code set
+    /// via `TimeZone(identifier: "UTC")`.
+    ///
+    /// The timezone check intentionally compares the fixed offset from GMT (always 0
+    /// for UTC) rather than the `TimeZone.identifier` string. Foundation canonicalizes
+    /// `TimeZone(identifier: "UTC").identifier` to `"GMT"` on Apple platforms, so a
+    /// literal `identifier == "UTC"` comparison would falsely report a mutation even
+    /// though the production code is correct. Checking `secondsFromGMT() == 0` is what
+    /// the `DateFormatter` actually uses during parsing, which is the invariant that
+    /// matters for correctness.
+    private static func assertDateFormatterInvariants(
+        _ entries: [(format: String, formatter: DateFormatter)],
+        label: String
+    ) {
+        for entry in entries {
+            #expect(
+                entry.formatter.dateFormat == entry.format,
+                "\(label): dateFormat mutated away from '\(entry.format)' (now '\(entry.formatter.dateFormat ?? "nil")')"
+            )
+            #expect(
+                entry.formatter.locale?.identifier == "en_US_POSIX",
+                "\(label): locale mutated away from en_US_POSIX for format '\(entry.format)'"
+            )
+            let zone = entry.formatter.timeZone
+            #expect(
+                zone != nil,
+                "\(label): timeZone became nil for format '\(entry.format)'"
+            )
+            #expect(
+                zone?.secondsFromGMT() == 0,
+                "\(label): timeZone mutated away from UTC for format '\(entry.format)' (now '\(zone?.identifier ?? "nil")' with offset \(zone?.secondsFromGMT() ?? -1)s)"
+            )
+        }
+    }
+
+    @Test("HoistedDateFormatters.zoned entries preserve format, locale, and timeZone at rest")
+    func hoistedZonedFormattersInvariantAtRest() {
+        Self.assertDateFormatterInvariants(
+            RSSParsingService.hoistedZonedFormattersForTesting,
+            label: "HoistedDateFormatters.zoned"
+        )
+    }
+
+    @Test("HoistedDateFormatters.zoneless entries preserve format, locale, and timeZone at rest")
+    func hoistedZonelessFormattersInvariantAtRest() {
+        Self.assertDateFormatterInvariants(
+            RSSParsingService.hoistedZonelessFormattersForTesting,
+            label: "HoistedDateFormatters.zoneless"
+        )
+    }
+
+    @Test("ISO8601Formatters preserve their formatOptions at rest")
+    func iso8601FormattersInvariantAtRest() {
+        let expectedStandard: ISO8601DateFormatter.Options = [.withInternetDateTime]
+        let expectedFractional: ISO8601DateFormatter.Options = [.withInternetDateTime, .withFractionalSeconds]
+        #expect(
+            RSSParsingService.iso8601StandardFormatterForTesting.formatOptions == expectedStandard
+        )
+        #expect(
+            RSSParsingService.iso8601FractionalFormatterForTesting.formatOptions == expectedFractional
+        )
+    }
+
+    @Test("HoistedDateFormatters.zoned entries are not mutated by parseDate")
+    func hoistedZonedFormattersInvariantAfterParse() throws {
+        // Representative pubDate inputs that each match one of the zoned formats
+        // declared in `HoistedDateFormatters.zoned`. Exercising the full list forces
+        // `parseDate` to walk through every entry in the array, which is where a
+        // stray `formatter.dateFormat = ...` would be most tempting to add.
+        let zonedInputs = [
+            "Mon, 06 Apr 2026 08:30:00 -0700",            // EEE, dd MMM yyyy HH:mm:ss Z
+            "Mon, 06 Apr 2026 08:30:00 GMT",              // EEE, dd MMM yyyy HH:mm:ss zzz
+            "Mon, 6 Apr 2026 08:30:00 -0700",             // EEE, d MMM yyyy HH:mm:ss Z
+            "Mon, 6 Apr 2026 08:30:00 GMT",               // EEE, d MMM yyyy HH:mm:ss zzz
+            "6 Apr 2026 08:30:00 -0700",                  // d MMM yyyy HH:mm:ss Z
+            "6 Apr 2026 08:30:00 GMT",                    // d MMM yyyy HH:mm:ss zzz
+            "Mon, 06 Apr 2026 08:30 -0700",               // EEE, dd MMM yyyy HH:mm Z
+            "Mon, 06 Apr 2026 08:30 GMT",                 // EEE, dd MMM yyyy HH:mm zzz
+            "2026-04-06T08:30:00-0700",                   // yyyy-MM-dd'T'HH:mm:ssZ
+            "2026-04-06T08:30:00.123-0700",               // yyyy-MM-dd'T'HH:mm:ss.SSSZ
+            "2026-04-06 08:30:00-0700",                   // yyyy-MM-dd HH:mm:ssZ
+            "2026-04-06 08:30:00 GMT",                    // yyyy-MM-dd HH:mm:ss zzz
+        ]
+
+        for input in zonedInputs {
+            let xml = Self.rssXML(pubDate: input)
+            let feed = try service.parse(Data(xml.utf8))
+            #expect(
+                feed.articles[0].publishedDate != nil,
+                "Expected zoned input '\(input)' to parse to a non-nil date"
+            )
+        }
+
+        Self.assertDateFormatterInvariants(
+            RSSParsingService.hoistedZonedFormattersForTesting,
+            label: "HoistedDateFormatters.zoned (post-parse)"
+        )
+    }
+
+    @Test("HoistedDateFormatters.zoneless entries are not mutated by parseDate")
+    func hoistedZonelessFormattersInvariantAfterParse() throws {
+        // Zoneless inputs designed to bypass every explicit-zone format (and the
+        // ISO8601 formatters) so `parseDate` falls through to the zoneless block.
+        // Each input matches one entry in `HoistedDateFormatters.zoneless`.
+        let zonelessInputs = [
+            "Mon, 06 Apr 2026 08:30:00",   // EEE, dd MMM yyyy HH:mm:ss
+            "Mon, 06 Apr 2026 08:30",      // EEE, dd MMM yyyy HH:mm
+            "06 Apr 2026 08:30:00",        // dd MMM yyyy HH:mm:ss
+            "2026-04-06T08:30:00.123",     // yyyy-MM-dd'T'HH:mm:ss.SSS
+            "2026-04-06T08:30:00",         // yyyy-MM-dd'T'HH:mm:ss
+            "2026-04-06 08:30:00",         // yyyy-MM-dd HH:mm:ss
+            "2026-04-06",                  // yyyy-MM-dd
+        ]
+
+        for input in zonelessInputs {
+            let xml = Self.rssXML(pubDate: input)
+            let feed = try service.parse(Data(xml.utf8))
+            #expect(
+                feed.articles[0].publishedDate != nil,
+                "Expected zoneless input '\(input)' to parse to a non-nil date"
+            )
+        }
+
+        Self.assertDateFormatterInvariants(
+            RSSParsingService.hoistedZonelessFormattersForTesting,
+            label: "HoistedDateFormatters.zoneless (post-parse)"
+        )
+    }
+
+    @Test("ISO8601Formatters are not mutated by parseDate")
+    func iso8601FormattersInvariantAfterParse() throws {
+        // `parseDate` tries the standard ISO8601 formatter first, then the fractional
+        // variant. Feeding it both shapes walks through both formatters.
+        let iso8601Inputs = [
+            "2026-04-06T08:30:00Z",         // standard
+            "2026-04-06T08:30:00.123Z",     // fractional
+        ]
+
+        for input in iso8601Inputs {
+            let xml = Self.rssXML(pubDate: input)
+            let feed = try service.parse(Data(xml.utf8))
+            #expect(
+                feed.articles[0].publishedDate != nil,
+                "Expected ISO 8601 input '\(input)' to parse to a non-nil date"
+            )
+        }
+
+        let expectedStandard: ISO8601DateFormatter.Options = [.withInternetDateTime]
+        let expectedFractional: ISO8601DateFormatter.Options = [.withInternetDateTime, .withFractionalSeconds]
+        #expect(
+            RSSParsingService.iso8601StandardFormatterForTesting.formatOptions == expectedStandard,
+            "ISO8601Formatters.standard formatOptions mutated by parseDate"
+        )
+        #expect(
+            RSSParsingService.iso8601FractionalFormatterForTesting.formatOptions == expectedFractional,
+            "ISO8601Formatters.fractional formatOptions mutated by parseDate"
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- Add six `@Test` cases that assert the pre-built `DateFormatter` and `ISO8601DateFormatter` instances in `RSSParserDelegate` retain their initial `dateFormat`, `locale`, `timeZone`, and `formatOptions`, both at rest and after `parseDate` walks every entry through the public `parse()` entry point.
- The `nonisolated(unsafe)` guarantee on these shared formatters depends on "initialized once, never mutated afterwards" holding forever. Today that is enforced only by code reading — these tests turn the invariant into a tripwire so a stray `formatter.dateFormat = ...` (or similar) added during future edits fails the suite rather than silently re-introducing the shared-mutable-state data race PR #241 was meant to remove.

## Changes
- `RSSApp/Services/RSSParsingService.swift`: add four internal static accessors (`hoistedZonedFormattersForTesting`, `hoistedZonelessFormattersForTesting`, `iso8601StandardFormatterForTesting`, `iso8601FractionalFormatterForTesting`) that proxy to the file-private nested enums; bump the nested `HoistedDateFormatters` / `ISO8601Formatters` from `private` to `fileprivate` so the accessors can reach them. Production code inside `RSSParserDelegate` is unchanged and keeps using the nested enums directly — exposing accessors rather than promoting the enums themselves keeps production callers from accidentally grabbing raw `DateFormatter` references.
- `RSSAppTests/Services/RSSParsingServiceTests.swift`: add an `assertDateFormatterInvariants` helper plus six `@Test` cases. Tests cover the static configuration at rest, the configuration after exercising every entry in `HoistedDateFormatters.zoned`/`zoneless` through `parse()` with matching pubDate strings, and the `formatOptions` on both `ISO8601Formatters`. The timezone assertion compares `secondsFromGMT() == 0` rather than `identifier == "UTC"` because Foundation canonicalizes `TimeZone(identifier: "UTC").identifier` to `"GMT"` on Apple platforms.

## Test plan
- [x] `xcodebuild ... test -only-testing:RSSAppTests/RSSParsingServiceTests` passes including the six new invariant tests
- [x] Full `xcodebuild ... test` suite passes
- [x] New tests run in parallel across simulator clones without flaking

Fixes #242