### PR TITLE
feat: Add Edit and Delete options to group article list toolbar menu (#339)

### DIFF
--- a/RSSApp/ViewModels/ArticleListSource.swift
+++ b/RSSApp/ViewModels/ArticleListSource.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import os
 
 /// Display content for an article list's empty state. Each `ArticleListSource`
 /// supplies its own so the shared view can render per-screen copy (e.g.
@@ -147,6 +148,10 @@ protocol ArticleListSource: AnyObject, Observable {
     func clearError()
 }
 
+/// A shared logger used by the `ArticleListSource` protocol extension defaults
+/// where no concrete type's logger is available.
+private let articleListSourceLogger = Logger(category: "ArticleListSource")
+
 extension ArticleListSource {
     func onDisappear() {}
 
@@ -163,9 +168,22 @@ extension ArticleListSource {
     /// Deletes the group backing this source. Called after the user confirms
     /// the delete alert. After this call, `wasGroupDeleted` must become `true`
     /// so `ArticleListScreen` can dismiss and pop the navigation stack.
-    func deleteGroup() {}
+    func deleteGroup() {
+        // RATIONALE: Defensive fault log + assertionFailure per project guidelines.
+        // This default fires only if a non-group source accidentally receives a
+        // deleteGroup() call — impossible in production UI but catchable in tests.
+        articleListSourceLogger.fault("deleteGroup() called on a source that does not support group editing")
+        assertionFailure("deleteGroup() called on a source that does not support group editing")
+    }
 
     /// Becomes `true` after a successful `deleteGroup()` call. Observed by
     /// `ArticleListScreen` to trigger auto-dismiss (pop back to Home).
     var wasGroupDeleted: Bool { false }
+
+    /// Error message set when `deleteGroup()` fails. Distinct from `errorMessage`
+    /// so the delete-error alert fires regardless of whether the article list is
+    /// empty — the `errorAlertBinding` gates on `!source.articles.isEmpty` to
+    /// avoid conflicts with the empty-state error row, but delete errors must
+    /// always surface to the user.
+    var deleteErrorMessage: String? { nil }
 }

--- a/RSSApp/ViewModels/ArticleListSource.swift
+++ b/RSSApp/ViewModels/ArticleListSource.swift
@@ -149,4 +149,23 @@ protocol ArticleListSource: AnyObject, Observable {
 
 extension ArticleListSource {
     func onDisappear() {}
+
+    // MARK: - Group editing (optional capability)
+
+    /// Whether this source supports in-screen group editing (Edit Group /
+    /// Delete Group). Only `GroupArticleSource` returns `true`.
+    var supportsGroupEdit: Bool { false }
+
+    /// The underlying `PersistentFeedGroup` for sources that support group
+    /// editing. `nil` for all non-group sources.
+    var editableGroup: PersistentFeedGroup? { nil }
+
+    /// Deletes the group backing this source. Called after the user confirms
+    /// the delete alert. After this call, `wasGroupDeleted` must become `true`
+    /// so `ArticleListScreen` can dismiss and pop the navigation stack.
+    func deleteGroup() {}
+
+    /// Becomes `true` after a successful `deleteGroup()` call. Observed by
+    /// `ArticleListScreen` to trigger auto-dismiss (pop back to Home).
+    var wasGroupDeleted: Bool { false }
 }

--- a/RSSApp/ViewModels/GroupArticleSource.swift
+++ b/RSSApp/ViewModels/GroupArticleSource.swift
@@ -36,6 +36,25 @@ final class GroupArticleSource: ArticleListSource {
     var supportsSort: Bool { true }
     var supportsUnreadFilter: Bool { false }
 
+    // MARK: - Group editing capability
+
+    var supportsGroupEdit: Bool { true }
+    var editableGroup: PersistentFeedGroup? { group }
+    private(set) var wasGroupDeleted: Bool = false
+
+    func deleteGroup() {
+        let name = group.name
+        do {
+            try persistence.deleteGroup(group)
+            homeViewModel.loadGroups()
+            wasGroupDeleted = true
+            Self.logger.notice("Deleted group '\(name, privacy: .public)' from GroupArticleSource")
+        } catch {
+            errorMessage = "Unable to delete group."
+            Self.logger.error("Failed to delete group '\(name, privacy: .public)': \(error, privacy: .public)")
+        }
+    }
+
     var sortAscending: Bool {
         get { homeViewModel.sortAscending }
         set {

--- a/RSSApp/ViewModels/GroupArticleSource.swift
+++ b/RSSApp/ViewModels/GroupArticleSource.swift
@@ -41,6 +41,7 @@ final class GroupArticleSource: ArticleListSource {
     var supportsGroupEdit: Bool { true }
     var editableGroup: PersistentFeedGroup? { group }
     private(set) var wasGroupDeleted: Bool = false
+    private(set) var deleteErrorMessage: String?
 
     func deleteGroup() {
         let name = group.name
@@ -50,7 +51,7 @@ final class GroupArticleSource: ArticleListSource {
             wasGroupDeleted = true
             Self.logger.notice("Deleted group '\(name, privacy: .public)' from GroupArticleSource")
         } catch {
-            errorMessage = "Unable to delete group."
+            deleteErrorMessage = "Unable to delete group."
             Self.logger.error("Failed to delete group '\(name, privacy: .public)': \(error, privacy: .public)")
         }
     }

--- a/RSSApp/Views/ArticleListScreen.swift
+++ b/RSSApp/Views/ArticleListScreen.swift
@@ -35,6 +35,7 @@ struct ArticleListScreen<Source: ArticleListSource>: View {
     @State private var showMarkAllReadConfirmation = false
     @State private var showEditGroupSheet = false
     @State private var showDeleteGroupConfirmation = false
+    @State private var deleteErrorMessage: String?
     @State private var hasAppeared = false
     // RATIONALE: Snapshot preservation across reader push/pop. See
     // ARCHITECTURE.md → "Snapshot preservation across reader push/pop (two gates)".
@@ -91,6 +92,11 @@ struct ArticleListScreen<Source: ArticleListSource>: View {
         } message: {
             Text(source.errorMessage ?? "")
         }
+        .alert("Error", isPresented: deleteErrorAlertBinding) {
+            Button("OK") { deleteErrorMessage = nil }
+        } message: {
+            Text(deleteErrorMessage ?? "")
+        }
         .alert(
             "Delete Group?",
             isPresented: $showDeleteGroupConfirmation,
@@ -103,7 +109,7 @@ struct ArticleListScreen<Source: ArticleListSource>: View {
         } message: { group in
             Text("\"\(group.name)\" will be deleted. Its feeds will not be removed.")
         }
-        .sheet(isPresented: $showEditGroupSheet) {
+        .sheet(isPresented: $showEditGroupSheet, onDismiss: { source.reload() }) {
             if let group = source.editableGroup {
                 EditGroupView(group: group, persistence: persistence)
             }
@@ -111,6 +117,11 @@ struct ArticleListScreen<Source: ArticleListSource>: View {
         .onChange(of: source.wasGroupDeleted) { _, deleted in
             if deleted {
                 dismiss()
+            }
+        }
+        .onChange(of: source.deleteErrorMessage) { _, message in
+            if let message {
+                deleteErrorMessage = message
             }
         }
         .task {
@@ -317,6 +328,16 @@ struct ArticleListScreen<Source: ArticleListSource>: View {
         Binding(
             get: { source.errorMessage != nil && !source.articles.isEmpty },
             set: { if !$0 { source.clearError() } }
+        )
+    }
+
+    /// Always shown when a delete-group failure occurs, regardless of whether
+    /// the article list is empty — delete errors must surface even on empty
+    /// groups, which are the most natural targets for deletion.
+    private var deleteErrorAlertBinding: Binding<Bool> {
+        Binding(
+            get: { deleteErrorMessage != nil },
+            set: { if !$0 { deleteErrorMessage = nil } }
         )
     }
 }

--- a/RSSApp/Views/ArticleListScreen.swift
+++ b/RSSApp/Views/ArticleListScreen.swift
@@ -29,8 +29,12 @@ struct ArticleListScreen<Source: ArticleListSource>: View {
         self.thumbnailService = thumbnailService
     }
 
+    @Environment(\.dismiss) private var dismiss
+
     @State private var selectedArticleIndex: Int?
     @State private var showMarkAllReadConfirmation = false
+    @State private var showEditGroupSheet = false
+    @State private var showDeleteGroupConfirmation = false
     @State private var hasAppeared = false
     // RATIONALE: Snapshot preservation across reader push/pop. See
     // ARCHITECTURE.md → "Snapshot preservation across reader push/pop (two gates)".
@@ -86,6 +90,28 @@ struct ArticleListScreen<Source: ArticleListSource>: View {
             Button("OK") { source.clearError() }
         } message: {
             Text(source.errorMessage ?? "")
+        }
+        .alert(
+            "Delete Group?",
+            isPresented: $showDeleteGroupConfirmation,
+            presenting: source.editableGroup
+        ) { group in
+            Button("Delete", role: .destructive) {
+                source.deleteGroup()
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: { group in
+            Text("\"\(group.name)\" will be deleted. Its feeds will not be removed.")
+        }
+        .sheet(isPresented: $showEditGroupSheet) {
+            if let group = source.editableGroup {
+                EditGroupView(group: group, persistence: persistence)
+            }
+        }
+        .onChange(of: source.wasGroupDeleted) { _, deleted in
+            if deleted {
+                dismiss()
+            }
         }
         .task {
             // RATIONALE: First half of the two-gate snapshot-preservation
@@ -259,6 +285,22 @@ struct ArticleListScreen<Source: ArticleListSource>: View {
                     showMarkAllReadConfirmation = true
                 } label: {
                     Label("Mark All as Read", systemImage: "checkmark.circle")
+                }
+
+                if source.supportsGroupEdit {
+                    Divider()
+
+                    Button {
+                        showEditGroupSheet = true
+                    } label: {
+                        Label("Edit Group", systemImage: "pencil")
+                    }
+
+                    Button(role: .destructive) {
+                        showDeleteGroupConfirmation = true
+                    } label: {
+                        Label("Delete Group", systemImage: "trash")
+                    }
                 }
             } label: {
                 Image(systemName: "ellipsis.circle")

--- a/RSSAppTests/ViewModels/GroupArticleSourceTests.swift
+++ b/RSSAppTests/ViewModels/GroupArticleSourceTests.swift
@@ -187,6 +187,30 @@ struct GroupArticleSourceTests {
         #expect(source.errorMessage == nil)
     }
 
+    // MARK: - Group deletion
+
+    @Test("deleteGroup() success sets wasGroupDeleted and removes group from persistence")
+    @MainActor
+    func deleteGroupSuccess() {
+        let (source, mock, group) = Self.makeFixture()
+        source.deleteGroup()
+
+        #expect(source.wasGroupDeleted == true)
+        #expect(source.deleteErrorMessage == nil)
+        #expect(!mock.groups.contains { $0.id == group.id })
+    }
+
+    @Test("deleteGroup() failure sets deleteErrorMessage and leaves wasGroupDeleted false")
+    @MainActor
+    func deleteGroupFailure() {
+        let (source, mock, _) = Self.makeFixture()
+        mock.groupError = NSError(domain: "test", code: 1)
+        source.deleteGroup()
+
+        #expect(source.wasGroupDeleted == false)
+        #expect(source.deleteErrorMessage != nil)
+    }
+
     // MARK: - Sort
 
     @Test("sortAscending toggle reloads articles in new order")


### PR DESCRIPTION
## Summary
- Users viewing a group's articles can now edit or delete the group directly from the toolbar overflow menu, eliminating the need to navigate back to the Home screen
- "Edit Group" presents the existing `EditGroupView` sheet; dismissing it triggers a reload so name and membership changes are reflected immediately
- "Delete Group" shows a confirmation alert matching the Home screen pattern; on confirmation the group is deleted and the navigation stack pops back to Home automatically
- The new items only appear when the source is a `GroupArticleSource` — all other article list screens (All Articles, Unread, Saved, per-feed) are unaffected

## Changes
- `ArticleListSource.swift` — added optional protocol extension capabilities (`supportsGroupEdit`, `editableGroup`, `deleteGroup()`, `wasGroupDeleted`) with no-op defaults
- `GroupArticleSource.swift` — implemented the group-edit capability; deletion goes through `FeedPersisting` directly for error-safe return-value semantics, only sets `wasGroupDeleted = true` on success
- `ArticleListScreen.swift` — added Edit Group / Delete Group toolbar menu items, `EditGroupView` sheet, delete confirmation alert, and `onChange(of: source.wasGroupDeleted)` for auto-dismiss after deletion

Closes #339