### PR TITLE
fix: Differentiate error messages in OPML import catch block

### DIFF
--- a/RSSApp/Models/OPMLImportResult.swift
+++ b/RSSApp/Models/OPMLImportResult.swift
@@ -3,18 +3,21 @@ import Foundation
 struct OPMLImportResult: Sendable, Equatable {
     let addedCount: Int
     let skippedCount: Int
+    let failedCount: Int
     let groupsCreatedCount: Int
     let groupsReusedCount: Int
-    var totalInFile: Int { addedCount + skippedCount }
+    var totalInFile: Int { addedCount + skippedCount + failedCount }
 
     init(
         addedCount: Int,
         skippedCount: Int,
+        failedCount: Int = 0,
         groupsCreatedCount: Int = 0,
         groupsReusedCount: Int = 0
     ) {
         self.addedCount = addedCount
         self.skippedCount = skippedCount
+        self.failedCount = failedCount
         self.groupsCreatedCount = groupsCreatedCount
         self.groupsReusedCount = groupsReusedCount
     }

--- a/RSSApp/Models/OPMLImportResult.swift
+++ b/RSSApp/Models/OPMLImportResult.swift
@@ -6,6 +6,7 @@ struct OPMLImportResult: Sendable, Equatable {
     let failedCount: Int
     let groupsCreatedCount: Int
     let groupsReusedCount: Int
+    let groupsFailedCount: Int
     var totalInFile: Int { addedCount + skippedCount + failedCount }
 
     init(
@@ -13,12 +14,14 @@ struct OPMLImportResult: Sendable, Equatable {
         skippedCount: Int,
         failedCount: Int = 0,
         groupsCreatedCount: Int = 0,
-        groupsReusedCount: Int = 0
+        groupsReusedCount: Int = 0,
+        groupsFailedCount: Int = 0
     ) {
         self.addedCount = addedCount
         self.skippedCount = skippedCount
         self.failedCount = failedCount
         self.groupsCreatedCount = groupsCreatedCount
         self.groupsReusedCount = groupsReusedCount
+        self.groupsFailedCount = groupsFailedCount
     }
 }

--- a/RSSApp/ViewModels/FeedListViewModel.swift
+++ b/RSSApp/ViewModels/FeedListViewModel.swift
@@ -142,6 +142,7 @@ final class FeedListViewModel {
         var failedCount = 0
         var groupsCreatedCount = 0
         var groupsReusedCount = 0
+        var groupsFailedCount = 0
 
         // Build a cache of existing groups by name so we can reuse them.
         var groupsByName: [String: PersistentFeedGroup]
@@ -225,6 +226,7 @@ final class FeedListViewModel {
                         createdGroupNames.insert(groupName)
                         reusedGroupNames.remove(groupName)
                     } catch {
+                        groupsFailedCount += 1
                         Self.logger.error("Failed to create group '\(groupName, privacy: .public)': \(error, privacy: .public)")
                         continue
                     }
@@ -232,6 +234,7 @@ final class FeedListViewModel {
                 do {
                     try persistence.addFeed(feed, to: group)
                 } catch {
+                    groupsFailedCount += 1
                     Self.logger.error("Failed to assign feed '\(entry.title, privacy: .public)' to group '\(groupName, privacy: .public)': \(error, privacy: .public)")
                 }
             }
@@ -246,14 +249,11 @@ final class FeedListViewModel {
             skippedCount: skippedCount,
             failedCount: failedCount,
             groupsCreatedCount: groupsCreatedCount,
-            groupsReusedCount: groupsReusedCount
+            groupsReusedCount: groupsReusedCount,
+            groupsFailedCount: groupsFailedCount
         )
-        if failedCount > 0 {
-            importExportErrorMessage = "Added \(addedCount) of \(addedCount + failedCount) new feed(s). \(failedCount) could not be saved."
-        } else {
-            importExportErrorMessage = nil
-        }
-        Self.logger.notice("OPML import: added \(addedCount, privacy: .public), skipped \(skippedCount, privacy: .public), failed \(failedCount, privacy: .public), groups created \(groupsCreatedCount, privacy: .public), groups reused \(groupsReusedCount, privacy: .public)")
+        importExportErrorMessage = nil
+        Self.logger.notice("OPML import: added \(addedCount, privacy: .public), skipped \(skippedCount, privacy: .public), failed \(failedCount, privacy: .public), groups created \(groupsCreatedCount, privacy: .public), groups reused \(groupsReusedCount, privacy: .public), groups failed \(groupsFailedCount, privacy: .public)")
     }
 
     func exportOPML() {

--- a/RSSApp/ViewModels/FeedListViewModel.swift
+++ b/RSSApp/ViewModels/FeedListViewModel.swift
@@ -139,6 +139,7 @@ final class FeedListViewModel {
 
         var addedCount = 0
         var skippedCount = 0
+        var failedCount = 0
         var groupsCreatedCount = 0
         var groupsReusedCount = 0
 
@@ -151,7 +152,7 @@ final class FeedListViewModel {
                 uniquingKeysWith: { first, _ in first }
             )
         } catch {
-            importExportErrorMessage = "Unable to save imported feeds."
+            importExportErrorMessage = "Unable to load existing groups. Import aborted."
             Self.logger.error("Failed to load existing groups: \(error, privacy: .public)")
             loadFeeds()
             return
@@ -166,7 +167,7 @@ final class FeedListViewModel {
                 uniquingKeysWith: { first, _ in first }
             )
         } catch {
-            importExportErrorMessage = "Unable to save imported feeds."
+            importExportErrorMessage = "Unable to load existing feeds. Import aborted."
             Self.logger.error("Failed to load existing feeds: \(error, privacy: .public)")
             loadFeeds()
             return
@@ -178,52 +179,61 @@ final class FeedListViewModel {
         var reusedGroupNames: Set<String> = []
 
         for entry in entries {
-            do {
-                let feed: PersistentFeed
+            // --- Add or look up the feed ---
+            let feed: PersistentFeed
 
-                if let existingFeed = feedsByURL[entry.feedURL] {
-                    feed = existingFeed
-                    skippedCount += 1
-                    Self.logger.debug("Skipped duplicate: \(entry.feedURL.absoluteString, privacy: .public)")
-                } else {
-                    let newFeed = PersistentFeed(
-                        title: entry.title,
-                        feedURL: entry.feedURL,
-                        feedDescription: entry.description
-                    )
+            if let existingFeed = feedsByURL[entry.feedURL] {
+                feed = existingFeed
+                skippedCount += 1
+                Self.logger.debug("Skipped duplicate: \(entry.feedURL.absoluteString, privacy: .public)")
+            } else {
+                let newFeed = PersistentFeed(
+                    title: entry.title,
+                    feedURL: entry.feedURL,
+                    feedDescription: entry.description
+                )
+                do {
                     try persistence.addFeed(newFeed)
                     feedsByURL[entry.feedURL] = newFeed
                     feed = newFeed
                     addedCount += 1
+                } catch {
+                    failedCount += 1
+                    Self.logger.error("Failed to add feed '\(entry.title, privacy: .public)': \(error, privacy: .public)")
+                    continue
                 }
+            }
 
-                // Assign the feed to its OPML category group if present.
-                if let groupName = entry.groupName {
-                    let group: PersistentFeedGroup
-                    if let existingGroup = groupsByName[groupName] {
-                        group = existingGroup
-                        if !createdGroupNames.contains(groupName) {
-                            reusedGroupNames.insert(groupName)
-                        }
-                    } else {
-                        let maxSortOrder = groupsByName.values.map(\.sortOrder).max() ?? -1
-                        let newGroup = PersistentFeedGroup(
-                            name: groupName,
-                            sortOrder: maxSortOrder + 1
-                        )
+            // --- Assign the feed to its OPML category group if present ---
+            if let groupName = entry.groupName {
+                let group: PersistentFeedGroup
+                if let existingGroup = groupsByName[groupName] {
+                    group = existingGroup
+                    if !createdGroupNames.contains(groupName) {
+                        reusedGroupNames.insert(groupName)
+                    }
+                } else {
+                    let maxSortOrder = groupsByName.values.map(\.sortOrder).max() ?? -1
+                    let newGroup = PersistentFeedGroup(
+                        name: groupName,
+                        sortOrder: maxSortOrder + 1
+                    )
+                    do {
                         try persistence.addGroup(newGroup)
                         groupsByName[groupName] = newGroup
                         group = newGroup
                         createdGroupNames.insert(groupName)
                         reusedGroupNames.remove(groupName)
+                    } catch {
+                        Self.logger.error("Failed to create group '\(groupName, privacy: .public)': \(error, privacy: .public)")
+                        continue
                     }
-                    try persistence.addFeed(feed, to: group)
                 }
-            } catch {
-                importExportErrorMessage = "Unable to save imported feeds."
-                Self.logger.error("Failed to persist OPML import: \(error, privacy: .public)")
-                loadFeeds()
-                return
+                do {
+                    try persistence.addFeed(feed, to: group)
+                } catch {
+                    Self.logger.error("Failed to assign feed '\(entry.title, privacy: .public)' to group '\(groupName, privacy: .public)': \(error, privacy: .public)")
+                }
             }
         }
 
@@ -234,11 +244,16 @@ final class FeedListViewModel {
         opmlImportResult = OPMLImportResult(
             addedCount: addedCount,
             skippedCount: skippedCount,
+            failedCount: failedCount,
             groupsCreatedCount: groupsCreatedCount,
             groupsReusedCount: groupsReusedCount
         )
-        importExportErrorMessage = nil
-        Self.logger.notice("OPML import: added \(addedCount, privacy: .public), skipped \(skippedCount, privacy: .public), groups created \(groupsCreatedCount, privacy: .public), groups reused \(groupsReusedCount, privacy: .public)")
+        if failedCount > 0 {
+            importExportErrorMessage = "Added \(addedCount) of \(addedCount + failedCount) new feed(s). \(failedCount) could not be saved."
+        } else {
+            importExportErrorMessage = nil
+        }
+        Self.logger.notice("OPML import: added \(addedCount, privacy: .public), skipped \(skippedCount, privacy: .public), failed \(failedCount, privacy: .public), groups created \(groupsCreatedCount, privacy: .public), groups reused \(groupsReusedCount, privacy: .public)")
     }
 
     func exportOPML() {

--- a/RSSApp/Views/SettingsView.swift
+++ b/RSSApp/Views/SettingsView.swift
@@ -282,7 +282,7 @@ struct ImportExportView: View {
     private func importResultMessage(_ result: OPMLImportResult) -> String {
         var parts: [String] = []
 
-        if result.addedCount == 0 && result.skippedCount > 0 && result.failedCount == 0 {
+        if result.addedCount == 0 && result.skippedCount > 0 && result.failedCount == 0 && result.groupsFailedCount == 0 {
             return "All \(result.skippedCount) feeds were already in your list."
         }
 
@@ -294,6 +294,13 @@ struct ImportExportView: View {
         }
         if result.failedCount > 0 {
             parts.append("\(result.failedCount) feed(s) could not be saved.")
+        }
+        if result.groupsFailedCount > 0 {
+            parts.append("\(result.groupsFailedCount) group assignment(s) failed.")
+        }
+
+        if parts.isEmpty {
+            return "No feeds were found in the file."
         }
 
         return parts.joined(separator: " ")

--- a/RSSApp/Views/SettingsView.swift
+++ b/RSSApp/Views/SettingsView.swift
@@ -280,13 +280,23 @@ struct ImportExportView: View {
     // MARK: - Helpers
 
     private func importResultMessage(_ result: OPMLImportResult) -> String {
-        if result.addedCount == 0 && result.skippedCount > 0 {
+        var parts: [String] = []
+
+        if result.addedCount == 0 && result.skippedCount > 0 && result.failedCount == 0 {
             return "All \(result.skippedCount) feeds were already in your list."
-        } else if result.skippedCount == 0 {
-            return "Added \(result.addedCount) feed(s)."
-        } else {
-            return "Added \(result.addedCount) feed(s). \(result.skippedCount) duplicate(s) skipped."
         }
+
+        if result.addedCount > 0 {
+            parts.append("Added \(result.addedCount) feed(s).")
+        }
+        if result.skippedCount > 0 {
+            parts.append("\(result.skippedCount) duplicate(s) skipped.")
+        }
+        if result.failedCount > 0 {
+            parts.append("\(result.failedCount) feed(s) could not be saved.")
+        }
+
+        return parts.joined(separator: " ")
     }
 
     private func handleFileImport(_ result: Result<URL, any Error>) {

--- a/RSSAppTests/Mocks/MockFeedPersistenceService.swift
+++ b/RSSAppTests/Mocks/MockFeedPersistenceService.swift
@@ -17,6 +17,8 @@ final class MockFeedPersistenceService: FeedPersisting {
     var upsertArticlesError: (any Error)?
     var updateFeedCacheHeadersError: (any Error)?
     var addFeedFailureAfterCount: Int?
+    var addGroupError: (any Error)?
+    var addFeedToGroupError: (any Error)?
 
     /// When non-zero, `allFeeds()` throws on the first N calls and then
     /// begins returning `feeds` normally. Counter decrements per call.
@@ -342,7 +344,7 @@ final class MockFeedPersistenceService: FeedPersisting {
     }
 
     func addGroup(_ group: PersistentFeedGroup) throws {
-        if let error = groupError ?? errorToThrow { throw error }
+        if let error = addGroupError ?? groupError ?? errorToThrow { throw error }
         groups.append(group)
     }
 
@@ -358,7 +360,7 @@ final class MockFeedPersistenceService: FeedPersisting {
     }
 
     func addFeed(_ feed: PersistentFeed, to group: PersistentFeedGroup) throws {
-        if let error = groupError ?? errorToThrow { throw error }
+        if let error = addFeedToGroupError ?? groupError ?? errorToThrow { throw error }
         let alreadyExists = memberships.contains {
             $0.feed?.id == feed.id && $0.group?.id == group.id
         }

--- a/RSSAppTests/ViewModels/FeedListViewModelTests.swift
+++ b/RSSAppTests/ViewModels/FeedListViewModelTests.swift
@@ -743,7 +743,7 @@ struct FeedListViewModelTests {
         #expect(viewModel.feeds.count == 1)
         #expect(viewModel.opmlImportResult?.addedCount == 1)
         #expect(viewModel.opmlImportResult?.failedCount == 2)
-        #expect(viewModel.importExportErrorMessage == "Added 1 of 3 new feed(s). 2 could not be saved.")
+        #expect(viewModel.importExportErrorMessage == nil)
         #expect(viewModel.errorMessage == nil)
     }
 
@@ -1020,6 +1020,7 @@ struct FeedListViewModelTests {
         // Feed should be added even though group creation failed.
         #expect(viewModel.opmlImportResult?.addedCount == 1)
         #expect(viewModel.opmlImportResult?.failedCount == 0)
+        #expect(viewModel.opmlImportResult?.groupsFailedCount == 1)
         #expect(mockPersistence.groups.isEmpty)
         #expect(mockPersistence.memberships.isEmpty)
     }
@@ -1037,9 +1038,10 @@ struct FeedListViewModelTests {
         let viewModel = Self.makeViewModel(persistence: mockPersistence, opmlService: mockOPML)
         viewModel.importOPML(from: Data())
 
-        // Feed and group should be created, but membership fails silently.
+        // Feed and group should be created, but membership assignment fails.
         #expect(viewModel.opmlImportResult?.addedCount == 1)
         #expect(viewModel.opmlImportResult?.failedCount == 0)
+        #expect(viewModel.opmlImportResult?.groupsFailedCount == 1)
         #expect(mockPersistence.groups.count == 1)
         #expect(mockPersistence.memberships.isEmpty)
     }
@@ -1097,7 +1099,7 @@ struct FeedListViewModelTests {
 
         #expect(viewModel.opmlImportResult?.addedCount == 0)
         #expect(viewModel.opmlImportResult?.failedCount == 2)
-        #expect(viewModel.importExportErrorMessage == "Added 0 of 2 new feed(s). 2 could not be saved.")
+        #expect(viewModel.importExportErrorMessage == nil)
     }
 
     // MARK: - OPML Export with Groups

--- a/RSSAppTests/ViewModels/FeedListViewModelTests.swift
+++ b/RSSAppTests/ViewModels/FeedListViewModelTests.swift
@@ -723,11 +723,11 @@ struct FeedListViewModelTests {
         #expect(viewModel.opmlImportResult?.skippedCount == 1)
     }
 
-    @Test("importOPML aborts early on persistence failure mid-import")
+    @Test("importOPML continues past persistence failures and reports partial progress")
     @MainActor
     func importOPMLPersistenceFailureMidImport() {
         let mockPersistence = MockFeedPersistenceService()
-        // First addFeed succeeds, second fails
+        // First addFeed succeeds, second and third fail
         mockPersistence.addFeedFailureAfterCount = 1
         let mockOPML = MockOPMLService()
         mockOPML.entriesToReturn = [
@@ -739,10 +739,11 @@ struct FeedListViewModelTests {
         let viewModel = Self.makeViewModel(persistence: mockPersistence, opmlService: mockOPML)
         viewModel.importOPML(from: Data())
 
-        // Only the first feed should have been added — import aborts on second
+        // First feed added successfully, remaining two failed — import continues
         #expect(viewModel.feeds.count == 1)
-        #expect(viewModel.opmlImportResult == nil)
-        #expect(viewModel.importExportErrorMessage != nil)
+        #expect(viewModel.opmlImportResult?.addedCount == 1)
+        #expect(viewModel.opmlImportResult?.failedCount == 2)
+        #expect(viewModel.importExportErrorMessage == "Added 1 of 3 new feed(s). 2 could not be saved.")
         #expect(viewModel.errorMessage == nil)
     }
 
@@ -1001,6 +1002,102 @@ struct FeedListViewModelTests {
         #expect(mockPersistence.memberships.count == 2)
         let groupNames = Set(mockPersistence.memberships.compactMap { $0.group?.name })
         #expect(groupNames == ["Tech", "Favorites"])
+    }
+
+    @Test("importOPML continues past group creation failure and still adds feed")
+    @MainActor
+    func importOPMLGroupCreationFailure() {
+        let mockPersistence = MockFeedPersistenceService()
+        mockPersistence.addGroupError = NSError(domain: "MockPersistence", code: 1)
+        let mockOPML = MockOPMLService()
+        mockOPML.entriesToReturn = [
+            OPMLFeedEntry(title: "Feed A", feedURL: URL(string: "https://a.com/feed")!, siteURL: nil, description: "", groupName: "Tech"),
+        ]
+
+        let viewModel = Self.makeViewModel(persistence: mockPersistence, opmlService: mockOPML)
+        viewModel.importOPML(from: Data())
+
+        // Feed should be added even though group creation failed.
+        #expect(viewModel.opmlImportResult?.addedCount == 1)
+        #expect(viewModel.opmlImportResult?.failedCount == 0)
+        #expect(mockPersistence.groups.isEmpty)
+        #expect(mockPersistence.memberships.isEmpty)
+    }
+
+    @Test("importOPML continues past group membership failure")
+    @MainActor
+    func importOPMLGroupMembershipFailure() {
+        let mockPersistence = MockFeedPersistenceService()
+        mockPersistence.addFeedToGroupError = NSError(domain: "MockPersistence", code: 1)
+        let mockOPML = MockOPMLService()
+        mockOPML.entriesToReturn = [
+            OPMLFeedEntry(title: "Feed A", feedURL: URL(string: "https://a.com/feed")!, siteURL: nil, description: "", groupName: "Tech"),
+        ]
+
+        let viewModel = Self.makeViewModel(persistence: mockPersistence, opmlService: mockOPML)
+        viewModel.importOPML(from: Data())
+
+        // Feed and group should be created, but membership fails silently.
+        #expect(viewModel.opmlImportResult?.addedCount == 1)
+        #expect(viewModel.opmlImportResult?.failedCount == 0)
+        #expect(mockPersistence.groups.count == 1)
+        #expect(mockPersistence.memberships.isEmpty)
+    }
+
+    @Test("importOPML reports distinct error for allGroups pre-loop failure")
+    @MainActor
+    func importOPMLAllGroupsPreLoopFailure() {
+        let mockPersistence = MockFeedPersistenceService()
+        mockPersistence.groupError = NSError(domain: "MockPersistence", code: 1)
+        let mockOPML = MockOPMLService()
+        mockOPML.entriesToReturn = [
+            TestFixtures.makeOPMLFeedEntry(title: "Feed A", feedURL: URL(string: "https://a.com/feed")!),
+        ]
+
+        let viewModel = Self.makeViewModel(persistence: mockPersistence, opmlService: mockOPML)
+        viewModel.importOPML(from: Data())
+
+        #expect(viewModel.importExportErrorMessage == "Unable to load existing groups. Import aborted.")
+        #expect(viewModel.opmlImportResult == nil)
+    }
+
+    @Test("importOPML reports distinct error for allFeeds pre-loop failure")
+    @MainActor
+    func importOPMLAllFeedsPreLoopFailure() {
+        let mockPersistence = MockFeedPersistenceService()
+        // Make only the first allFeeds() call fail (the pre-loop cache lookup),
+        // while the subsequent loadFeeds() call succeeds.
+        mockPersistence.allFeedsFailureCount = 1
+        let mockOPML = MockOPMLService()
+        mockOPML.entriesToReturn = [
+            TestFixtures.makeOPMLFeedEntry(title: "Feed A", feedURL: URL(string: "https://a.com/feed")!),
+        ]
+
+        let viewModel = Self.makeViewModel(persistence: mockPersistence, opmlService: mockOPML)
+        viewModel.importOPML(from: Data())
+
+        #expect(viewModel.importExportErrorMessage == "Unable to load existing feeds. Import aborted.")
+        #expect(viewModel.opmlImportResult == nil)
+    }
+
+    @Test("importOPML with all feeds failing reports zero added")
+    @MainActor
+    func importOPMLAllFeedsFail() {
+        let mockPersistence = MockFeedPersistenceService()
+        // All addFeed calls fail (after 0 successful)
+        mockPersistence.addFeedFailureAfterCount = 0
+        let mockOPML = MockOPMLService()
+        mockOPML.entriesToReturn = [
+            TestFixtures.makeOPMLFeedEntry(title: "Feed A", feedURL: URL(string: "https://a.com/feed")!),
+            TestFixtures.makeOPMLFeedEntry(title: "Feed B", feedURL: URL(string: "https://b.com/feed")!),
+        ]
+
+        let viewModel = Self.makeViewModel(persistence: mockPersistence, opmlService: mockOPML)
+        viewModel.importOPML(from: Data())
+
+        #expect(viewModel.opmlImportResult?.addedCount == 0)
+        #expect(viewModel.opmlImportResult?.failedCount == 2)
+        #expect(viewModel.importExportErrorMessage == "Added 0 of 2 new feed(s). 2 could not be saved.")
     }
 
     // MARK: - OPML Export with Groups


### PR DESCRIPTION
## Summary
- Split the monolithic catch block in `importOPML` into per-operation error handling so failures report which operation failed and how much progress was made
- Individual feed, group creation, and group membership failures no longer abort the entire import; the loop continues and surfaces partial progress to the user
- Pre-loop failures (`allGroups()`, `allFeeds()`) now report distinct messages ("Unable to load existing groups/feeds. Import aborted.")

Fixes #350

## Test plan
- [x] Built successfully for iOS 26
- [x] All existing tests pass
- [x] New tests cover: continue-on-error with partial progress, group creation failure, group membership failure, pre-loop allGroups failure, pre-loop allFeeds failure, all-feeds-fail scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)