### PR TITLE
fix: Correct text colors in Edit Group feed rows (#340)

### DIFF
--- a/RSSApp/Views/EditFeedView.swift
+++ b/RSSApp/Views/EditFeedView.swift
@@ -42,10 +42,11 @@ struct EditFeedView: View {
                                     Spacer()
                                     if viewModel.memberGroupIDs.contains(group.id) {
                                         Image(systemName: "checkmark")
-                                            .foregroundStyle(.blue)
+                                            .foregroundStyle(.tint)
                                     }
                                 }
                             }
+                            .buttonStyle(.plain)
                         }
                     } header: {
                         Text("Groups")

--- a/RSSApp/Views/EditGroupView.swift
+++ b/RSSApp/Views/EditGroupView.swift
@@ -46,10 +46,11 @@ struct EditGroupView: View {
                                     Spacer()
                                     if viewModel.memberFeedIDs.contains(feed.id) {
                                         Image(systemName: "checkmark")
-                                            .foregroundStyle(.blue)
+                                            .foregroundStyle(.tint)
                                     }
                                 }
                             }
+                            .buttonStyle(.plain)
                         }
                     }
                 } header: {


### PR DESCRIPTION
## Summary
- Feed name and URL text in Edit Group now display in standard primary/secondary colors instead of being overridden by SwiftUI's default button tint
- Checkmark indicator uses `.tint` (system accent color) instead of hardcoded `.blue` for consistency with system conventions

## Changes
- Added `.buttonStyle(.plain)` to feed row `Button` in `EditGroupView` to prevent SwiftUI's default button style from applying blue tint to all label content
- Changed checkmark `foregroundStyle` from `.blue` to `.tint`

## Test plan
- [x] Built successfully for iOS 26
- [x] All existing tests pass
- [ ] Visually verified feed names display in primary (black/white) color
- [ ] Visually verified feed URLs display in secondary (grey) color
- [ ] Visually verified checkmark uses system accent color

Fixes #340