### PR TITLE
fix: Batch-fetch group memberships in OPML export to avoid N+1 queries

### DIFF
--- a/RSSApp/Services/FeedPersistenceService.swift
+++ b/RSSApp/Services/FeedPersistenceService.swift
@@ -165,6 +165,9 @@ protocol FeedPersisting: Sendable {
     func removeFeed(_ feed: PersistentFeed, from group: PersistentFeedGroup) throws
     func feeds(in group: PersistentFeedGroup) throws -> [PersistentFeed]
     func groups(for feed: PersistentFeed) throws -> [PersistentFeedGroup]
+    /// Returns all group memberships in a single query. Use this for bulk
+    /// operations (e.g. OPML export) to avoid N+1 per-feed queries.
+    func allGroupMemberships() throws -> [PersistentFeedGroupMembership]
 
     /// Returns a page of articles from all feeds in the group, sorted by `sortDate`,
     /// using cursor-based pagination. Fetches only `limit` articles per feed regardless
@@ -994,6 +997,13 @@ final class SwiftDataFeedPersistenceService: FeedPersisting {
             .sorted { $0.sortOrder < $1.sortOrder }
         Self.logger.debug("Feed '\(feed.title, privacy: .public)' belongs to \(groups.count, privacy: .public) groups")
         return groups
+    }
+
+    func allGroupMemberships() throws -> [PersistentFeedGroupMembership] {
+        let descriptor = FetchDescriptor<PersistentFeedGroupMembership>()
+        let memberships = try modelContext.fetch(descriptor)
+        Self.logger.debug("Fetched \(memberships.count, privacy: .public) group memberships")
+        return memberships
     }
 
     // RATIONALE: SwiftData's #Predicate does not support `array.contains(keypath)` on

--- a/RSSApp/ViewModels/FeedListViewModel.swift
+++ b/RSSApp/ViewModels/FeedListViewModel.swift
@@ -286,9 +286,18 @@ final class FeedListViewModel {
         importExportErrorMessage = nil
         Self.logger.debug("exportOPML() called")
         do {
-            let groupedFeeds: [GroupedFeed] = try feeds.map { feed in
-                let groups = try persistence.groups(for: feed)
-                let groupNames = groups.map(\.name)
+            // Fetch all memberships in one query and build a lookup table so the
+            // per-feed group-name resolution below is O(1) instead of N queries.
+            let allMemberships = try persistence.allGroupMemberships()
+            var groupNamesByFeedID: [UUID: [String]] = [:]
+            for membership in allMemberships {
+                guard let feedID = membership.feed?.id,
+                      let groupName = membership.group?.name else { continue }
+                groupNamesByFeedID[feedID, default: []].append(groupName)
+            }
+
+            let groupedFeeds: [GroupedFeed] = feeds.map { feed in
+                let groupNames = groupNamesByFeedID[feed.id] ?? []
                 return GroupedFeed(feed: feed.toSubscribedFeed(), groupNames: groupNames)
             }
             let data = try opmlService.generateOPML(from: groupedFeeds)

--- a/RSSApp/ViewModels/FeedListViewModel.swift
+++ b/RSSApp/ViewModels/FeedListViewModel.swift
@@ -285,17 +285,29 @@ final class FeedListViewModel {
     func exportOPML() {
         importExportErrorMessage = nil
         Self.logger.debug("exportOPML() called")
-        do {
-            // Fetch all memberships in one query and build a lookup table so the
-            // per-feed group-name resolution below is O(1) instead of N queries.
-            let allMemberships = try persistence.allGroupMemberships()
-            var groupNamesByFeedID: [UUID: [String]] = [:]
-            for membership in allMemberships {
-                guard let feedID = membership.feed?.id,
-                      let groupName = membership.group?.name else { continue }
-                groupNamesByFeedID[feedID, default: []].append(groupName)
-            }
 
+        // Fetch all memberships in one query and build a lookup table so the
+        // per-feed group-name resolution below is O(1) instead of N queries.
+        let allMemberships: [PersistentFeedGroupMembership]
+        do {
+            allMemberships = try persistence.allGroupMemberships()
+        } catch {
+            importExportErrorMessage = "Unable to export feeds."
+            Self.logger.error("OPML export failed — could not fetch group memberships: \(error, privacy: .public)")
+            return
+        }
+
+        var groupNamesByFeedID: [UUID: [String]] = [:]
+        for membership in allMemberships {
+            guard let feedID = membership.feed?.id,
+                  let groupName = membership.group?.name else {
+                Self.logger.warning("Skipping membership with nil feed or group during OPML export — orphaned record in SwiftData")
+                continue
+            }
+            groupNamesByFeedID[feedID, default: []].append(groupName)
+        }
+
+        do {
             let groupedFeeds: [GroupedFeed] = feeds.map { feed in
                 let groupNames = groupNamesByFeedID[feed.id] ?? []
                 return GroupedFeed(feed: feed.toSubscribedFeed(), groupNames: groupNames)
@@ -307,7 +319,7 @@ final class FeedListViewModel {
             opmlExportURL = tempURL
         } catch {
             importExportErrorMessage = "Unable to export feeds."
-            Self.logger.error("OPML export failed: \(error, privacy: .public)")
+            Self.logger.error("OPML export failed — could not generate or write OPML data: \(error, privacy: .public)")
         }
     }
 

--- a/RSSAppTests/Mocks/MockFeedPersistenceService.swift
+++ b/RSSAppTests/Mocks/MockFeedPersistenceService.swift
@@ -427,6 +427,11 @@ final class MockFeedPersistenceService: FeedPersisting {
             .sorted { $0.sortOrder < $1.sortOrder }
     }
 
+    func allGroupMemberships() throws -> [PersistentFeedGroupMembership] {
+        if let error = groupError ?? errorToThrow { throw error }
+        return memberships
+    }
+
     func articles(in group: PersistentFeedGroup, cursor: ArticlePaginationCursor?, limit: Int, ascending: Bool = false) throws -> [PersistentArticle] {
         if let error = groupError ?? errorToThrow { throw error }
         let feedIDs = Set(memberships.filter { $0.group?.id == group.id }.compactMap { $0.feed?.id })

--- a/RSSAppTests/ViewModels/FeedListViewModelTests.swift
+++ b/RSSAppTests/ViewModels/FeedListViewModelTests.swift
@@ -1153,6 +1153,7 @@ struct FeedListViewModelTests {
 
         #expect(viewModel.opmlExportURL == nil)
         #expect(viewModel.importExportErrorMessage == "Unable to export feeds.")
+        #expect(viewModel.errorMessage == nil)
     }
 
     // MARK: - Refresh Delegation — outcome → errorMessage translation

--- a/RSSAppTests/ViewModels/FeedListViewModelTests.swift
+++ b/RSSAppTests/ViewModels/FeedListViewModelTests.swift
@@ -1137,6 +1137,24 @@ struct FeedListViewModelTests {
         #expect(feedBGrouped?.groupNames == [])
     }
 
+    @Test("exportOPML sets error when allGroupMemberships throws")
+    @MainActor
+    func exportOPMLGroupMembershipsError() {
+        let mockPersistence = MockFeedPersistenceService()
+        mockPersistence.feeds = [TestFixtures.makePersistentFeed()]
+        mockPersistence.groupError = NSError(domain: "test", code: 1)
+
+        let mockOPML = MockOPMLService()
+        mockOPML.dataToReturn = Data("opml-content".utf8)
+
+        let viewModel = Self.makeViewModel(persistence: mockPersistence, opmlService: mockOPML)
+        viewModel.loadFeeds()
+        viewModel.exportOPML()
+
+        #expect(viewModel.opmlExportURL == nil)
+        #expect(viewModel.importExportErrorMessage == "Unable to export feeds.")
+    }
+
     // MARK: - Refresh Delegation — outcome → errorMessage translation
     //
     // These tests defend the `refreshAllFeeds()` switch that maps a


### PR DESCRIPTION
## Summary
- Replaces the per-feed `groups(for:)` loop in `exportOPML()` with a single `allGroupMemberships()` fetch, reducing database queries from O(N) to O(1) for N feeds

## Changes
- Adds `allGroupMemberships() throws -> [PersistentFeedGroupMembership]` to the `FeedPersisting` protocol
- Implements `allGroupMemberships()` in `SwiftDataFeedPersistenceService` with a single `FetchDescriptor<PersistentFeedGroupMembership>` fetch
- Updates `exportOPML()` in `FeedListViewModel` to build a `[UUID: [String]]` feed-ID-to-group-names dictionary from the bulk result instead of issuing one query per feed
- Adds `allGroupMemberships()` to `MockFeedPersistenceService` for test coverage
- Adds test `exportOPMLGroupMembershipsError` covering the error path when `allGroupMemberships()` throws

## Test plan
- [x] All existing tests pass
- [x] New test `exportOPMLGroupMembershipsError` verifies the error is surfaced correctly

Fixes #351