### PR TITLE
refactor: Extract duplicated icon resolution wiring (#360)

### DIFF
--- a/RSSApp/Services/FeedPersistenceService.swift
+++ b/RSSApp/Services/FeedPersistenceService.swift
@@ -189,6 +189,22 @@ protocol FeedPersisting: Sendable {
     func save() throws
 }
 
+// MARK: - Icon Resolution Helpers
+
+extension FeedPersisting {
+    /// Applies a resolved icon to a feed. A no-op when `resolution` is `nil`.
+    /// Centralises the early-return-on-nil + `updateFeedIcon` call that
+    /// `FeedRefreshService` and `AddFeedViewModel` previously duplicated,
+    /// so both call sites evolve together when the resolution result type changes.
+    func applyIconResolution(
+        _ resolution: (url: URL, backgroundStyle: FeedIconBackgroundStyle)?,
+        to feed: PersistentFeed
+    ) throws {
+        guard let resolved = resolution else { return }
+        try updateFeedIcon(feed, iconURL: resolved.url, backgroundStyle: resolved.backgroundStyle)
+    }
+}
+
 // MARK: - SwiftData Implementation
 
 @MainActor

--- a/RSSApp/Services/FeedRefreshService.swift
+++ b/RSSApp/Services/FeedRefreshService.swift
@@ -682,12 +682,12 @@ final class FeedRefreshService {
             feedID: feed.id
         )
         do {
+            try persistence.applyIconResolution(resolved, to: feed)
+        } catch {
             // RATIONALE: No error surfaced to the caller. This runs inside a fire-and-forget
             // Task spawned by performRefresh(), so mutating the caller's errorMessage would
             // race with the post-refresh error state assignment. Icon persistence failure is
             // also cosmetic and self-healing — the icon is re-resolved on the next refresh.
-            try persistence.applyIconResolution(resolved, to: feed)
-        } catch {
             Self.logger.error("Failed to persist icon URL for '\(feed.title, privacy: .public)': \(error, privacy: .public)")
         }
     }

--- a/RSSApp/Services/FeedRefreshService.swift
+++ b/RSSApp/Services/FeedRefreshService.swift
@@ -676,22 +676,18 @@ final class FeedRefreshService {
             }
             return
         }
-        guard let resolved = await feedIconService.resolveAndCacheIcon(
+        let resolved = await feedIconService.resolveAndCacheIcon(
             feedSiteURL: siteURL,
             feedImageURL: feedImageURL,
             feedID: feed.id
-        ) else { return }
+        )
         do {
-            try persistence.updateFeedIcon(
-                feed,
-                iconURL: resolved.url,
-                backgroundStyle: resolved.backgroundStyle
-            )
+            // RATIONALE: No error surfaced to the caller. This runs inside a fire-and-forget
+            // Task spawned by performRefresh(), so mutating the caller's errorMessage would
+            // race with the post-refresh error state assignment. Icon persistence failure is
+            // also cosmetic and self-healing — the icon is re-resolved on the next refresh.
+            try persistence.applyIconResolution(resolved, to: feed)
         } catch {
-            // RATIONALE: No error surfaced here. This runs inside a fire-and-forget Task
-            // spawned by performRefresh(), so mutating the caller's errorMessage would race
-            // with the post-refresh error state assignment. Icon persistence failure is also
-            // cosmetic and self-healing — the icon is re-resolved on the next refresh.
             Self.logger.error("Failed to persist icon URL for '\(feed.title, privacy: .public)': \(error, privacy: .public)")
         }
     }

--- a/RSSApp/ViewModels/AddFeedViewModel.swift
+++ b/RSSApp/ViewModels/AddFeedViewModel.swift
@@ -266,6 +266,7 @@ final class AddFeedViewModel {
                 feedImageURL: feedImageURL,
                 feedID: newFeed.id
             )
+            guard resolved != nil else { return }
             do {
                 try persistenceRef.applyIconResolution(resolved, to: newFeed)
                 try persistenceRef.save()

--- a/RSSApp/ViewModels/AddFeedViewModel.swift
+++ b/RSSApp/ViewModels/AddFeedViewModel.swift
@@ -261,17 +261,13 @@ final class AddFeedViewModel {
         let feedImageURL = rssFeed.imageURL
         let persistenceRef = self.persistence
         Task {
-            guard let resolved = await iconService.resolveAndCacheIcon(
+            let resolved = await iconService.resolveAndCacheIcon(
                 feedSiteURL: siteURL,
                 feedImageURL: feedImageURL,
                 feedID: newFeed.id
-            ) else { return }
+            )
             do {
-                try persistenceRef.updateFeedIcon(
-                    newFeed,
-                    iconURL: resolved.url,
-                    backgroundStyle: resolved.backgroundStyle
-                )
+                try persistenceRef.applyIconResolution(resolved, to: newFeed)
                 try persistenceRef.save()
             } catch {
                 Self.logger.error("Failed to persist icon for '\(feedTitle, privacy: .public)': \(error, privacy: .public)")


### PR DESCRIPTION
## Summary
- Removes a near-identical 4-line block duplicated across `FeedRefreshService.resolveAndCacheIconIfNeeded` and `AddFeedViewModel.persistFetchedFeed`
- Adds a `applyIconResolution(_:to:)` protocol extension on `FeedPersisting` that centralizes the early-return-on-nil guard and `updateFeedIcon` call
- Both call sites now delegate to the helper, so any future evolution of the resolution result type only needs one change

## Changes
- `RSSApp/Services/FeedPersistenceService.swift` — new `// MARK: - Icon Resolution Helpers` extension with `applyIconResolution(_:to:)` default impl
- `RSSApp/Services/FeedRefreshService.swift` — `resolveAndCacheIconIfNeeded` calls helper instead of inlining the guard + updateFeedIcon
- `RSSApp/ViewModels/AddFeedViewModel.swift` — fire-and-forget Task calls helper (retains the `save()` call unique to the add path)

## Test plan
- [x] All existing tests pass (1107 test cases, 0 failures)
- [x] No new production code seams needed — protocol extension is usable from existing mock without changes

Closes #360