### PR TITLE
fix: Add feedID context to pngData failure warning in writeNormalizedIcon

### DIFF
--- a/RSSApp/Services/FeedIconService.swift
+++ b/RSSApp/Services/FeedIconService.swift
@@ -867,7 +867,7 @@ struct FeedIconService: FeedIconResolving {
     /// Returns the background style classification on success, `nil` on PNG-encode or write failure.
     private func writeNormalizedIcon(image: UIImage, stats: IconPixelStats, from remoteURL: URL, feedID: UUID) async -> FeedIconBackgroundStyle? {
         guard let pngData = image.pngData() else {
-            Self.logger.warning("writeNormalizedIcon: failed to generate PNG data for \(remoteURL.absoluteString, privacy: .public)")
+            Self.logger.warning("writeNormalizedIcon: failed to generate PNG data for \(remoteURL.absoluteString, privacy: .public) (feed \(feedID.uuidString, privacy: .public))")
             return nil
         }
         do {


### PR DESCRIPTION
## Summary
- Adds `feedID` to the `warning` log message emitted when `pngData()` encoding fails in `writeNormalizedIcon`, so the failure can be correlated with a specific feed in post-mortem log streams.

Fixes #369

## Test plan
- [x] Built successfully for iOS 26
- [x] All existing tests pass