### PR TITLE
feat: Expand OPML import notification with group counts and actionable errors (#354)

### DIFF
--- a/RSSApp/Models/OPMLImportResult.swift
+++ b/RSSApp/Models/OPMLImportResult.swift
@@ -24,4 +24,49 @@ struct OPMLImportResult: Sendable, Equatable {
         self.groupsReusedCount = groupsReusedCount
         self.groupsFailedCount = groupsFailedCount
     }
+
+    /// A user-facing multi-line bulleted summary of the import result.
+    var importSummary: String {
+        if addedCount == 0 && skippedCount > 0 && failedCount == 0 && groupsFailedCount == 0 {
+            return "All \(skippedCount) \(skippedCount == 1 ? "feed was" : "feeds were") already in your list."
+        }
+
+        if totalInFile == 0 && groupsCreatedCount == 0 && groupsReusedCount == 0 && groupsFailedCount == 0 {
+            return "No feeds were found in the file."
+        }
+
+        var lines: [String] = ["Imported from OPML:"]
+
+        if addedCount > 0 {
+            lines.append("• \(addedCount) new \(addedCount == 1 ? "feed" : "feeds") added")
+        }
+        if skippedCount > 0 {
+            lines.append("• \(skippedCount) \(skippedCount == 1 ? "duplicate" : "duplicates") skipped")
+        }
+
+        let hasGroupActivity = groupsCreatedCount > 0 || groupsReusedCount > 0
+        if hasGroupActivity {
+            var groupParts: [String] = []
+            if groupsCreatedCount > 0 {
+                groupParts.append("\(groupsCreatedCount) new \(groupsCreatedCount == 1 ? "group" : "groups") created")
+            }
+            if groupsReusedCount > 0 {
+                groupParts.append("\(groupsReusedCount) existing \(groupsReusedCount == 1 ? "group" : "groups") reused")
+            }
+            lines.append("• \(groupParts.joined(separator: ", "))")
+        }
+
+        if failedCount > 0 {
+            lines.append(
+                "• \(failedCount) \(failedCount == 1 ? "feed" : "feeds") couldn't be saved — check the feed URL and try re-importing"
+            )
+        }
+        if groupsFailedCount > 0 {
+            lines.append(
+                "• \(groupsFailedCount) group \(groupsFailedCount == 1 ? "assignment" : "assignments") failed — check Settings logs and try re-importing"
+            )
+        }
+
+        return lines.joined(separator: "\n")
+    }
 }

--- a/RSSApp/Models/OPMLImportResult.swift
+++ b/RSSApp/Models/OPMLImportResult.swift
@@ -27,7 +27,8 @@ struct OPMLImportResult: Sendable, Equatable {
 
     /// A user-facing multi-line bulleted summary of the import result.
     var importSummary: String {
-        if addedCount == 0 && skippedCount > 0 && failedCount == 0 && groupsFailedCount == 0 {
+        if addedCount == 0 && skippedCount > 0 && failedCount == 0
+            && groupsCreatedCount == 0 && groupsReusedCount == 0 && groupsFailedCount == 0 {
             return "All \(skippedCount) \(skippedCount == 1 ? "feed was" : "feeds were") already in your list."
         }
 

--- a/RSSApp/Views/SettingsView.swift
+++ b/RSSApp/Views/SettingsView.swift
@@ -253,7 +253,7 @@ struct ImportExportView: View {
         .alert("Import Complete", isPresented: $showImportResult, presenting: viewModel.opmlImportResult) { _ in
             Button("OK") { viewModel.opmlImportResult = nil }
         } message: { result in
-            Text(importResultMessage(result))
+            Text(result.importSummary)
         }
         .alert("Error", isPresented: $showError) {
             Button("OK") { viewModel.importExportErrorMessage = nil }
@@ -278,33 +278,6 @@ struct ImportExportView: View {
     }
 
     // MARK: - Helpers
-
-    private func importResultMessage(_ result: OPMLImportResult) -> String {
-        var parts: [String] = []
-
-        if result.addedCount == 0 && result.skippedCount > 0 && result.failedCount == 0 && result.groupsFailedCount == 0 {
-            return "All \(result.skippedCount) feeds were already in your list."
-        }
-
-        if result.addedCount > 0 {
-            parts.append("Added \(result.addedCount) feed(s).")
-        }
-        if result.skippedCount > 0 {
-            parts.append("\(result.skippedCount) duplicate(s) skipped.")
-        }
-        if result.failedCount > 0 {
-            parts.append("\(result.failedCount) feed(s) could not be saved.")
-        }
-        if result.groupsFailedCount > 0 {
-            parts.append("\(result.groupsFailedCount) group assignment(s) failed.")
-        }
-
-        if parts.isEmpty {
-            return "No feeds were found in the file."
-        }
-
-        return parts.joined(separator: " ")
-    }
 
     private func handleFileImport(_ result: Result<URL, any Error>) {
         switch result {

--- a/RSSAppTests/Models/OPMLImportResultTests.swift
+++ b/RSSAppTests/Models/OPMLImportResultTests.swift
@@ -151,4 +151,22 @@ struct OPMLImportResultTests {
         #expect(summary.contains("3 duplicates skipped"))
         #expect(summary.contains("group assignment failed"))
     }
+
+    @Test("All-duplicates special case is not triggered when feed failures also present")
+    func allDuplicatesWithFeedFailureNotSpecialCased() {
+        let result = OPMLImportResult(addedCount: 0, skippedCount: 3, failedCount: 1)
+        let summary = result.importSummary
+        #expect(summary.hasPrefix("Imported from OPML:"))
+        #expect(summary.contains("3 duplicates skipped"))
+        #expect(summary.contains("feed couldn't be saved"))
+    }
+
+    @Test("All-duplicates special case is not triggered when groups were created")
+    func allDuplicatesWithGroupCreationNotSpecialCased() {
+        let result = OPMLImportResult(addedCount: 0, skippedCount: 2, groupsCreatedCount: 1)
+        let summary = result.importSummary
+        #expect(summary.hasPrefix("Imported from OPML:"))
+        #expect(summary.contains("2 duplicates skipped"))
+        #expect(summary.contains("group"))
+    }
 }

--- a/RSSAppTests/Models/OPMLImportResultTests.swift
+++ b/RSSAppTests/Models/OPMLImportResultTests.swift
@@ -1,0 +1,154 @@
+import Testing
+import Foundation
+@testable import RSSApp
+
+@Suite("OPMLImportResult.importSummary Tests")
+struct OPMLImportResultTests {
+
+    // MARK: - Special-case messages
+
+    @Test("All duplicates returns singular short message")
+    func allDuplicatesSingular() {
+        let result = OPMLImportResult(addedCount: 0, skippedCount: 1)
+        #expect(result.importSummary == "All 1 feed was already in your list.")
+    }
+
+    @Test("All duplicates returns plural short message")
+    func allDuplicatesPlural() {
+        let result = OPMLImportResult(addedCount: 0, skippedCount: 5)
+        #expect(result.importSummary == "All 5 feeds were already in your list.")
+    }
+
+    @Test("Empty file returns no-feeds message")
+    func emptyFile() {
+        let result = OPMLImportResult(addedCount: 0, skippedCount: 0)
+        #expect(result.importSummary == "No feeds were found in the file.")
+    }
+
+    // MARK: - Feeds-only (no groups)
+
+    @Test("Added-only shows header and feed count")
+    func addedOnly() {
+        let result = OPMLImportResult(addedCount: 3, skippedCount: 0)
+        let summary = result.importSummary
+        #expect(summary.hasPrefix("Imported from OPML:"))
+        #expect(summary.contains("3 new feeds added"))
+        #expect(!summary.contains("duplicate"))
+        #expect(!summary.contains("group"))
+    }
+
+    @Test("Added singular uses 'feed' not 'feeds'")
+    func addedSingular() {
+        let result = OPMLImportResult(addedCount: 1, skippedCount: 0)
+        #expect(result.importSummary.contains("1 new feed added"))
+    }
+
+    @Test("Added and skipped shows both lines")
+    func addedAndSkipped() {
+        let result = OPMLImportResult(addedCount: 4, skippedCount: 2)
+        let summary = result.importSummary
+        #expect(summary.contains("4 new feeds added"))
+        #expect(summary.contains("2 duplicates skipped"))
+    }
+
+    @Test("Skipped singular uses 'duplicate' not 'duplicates'")
+    func skippedSingular() {
+        let result = OPMLImportResult(addedCount: 2, skippedCount: 1)
+        #expect(result.importSummary.contains("1 duplicate skipped"))
+    }
+
+    // MARK: - Group counts
+
+    @Test("New groups created line appears with correct count")
+    func newGroupsCreated() {
+        let result = OPMLImportResult(addedCount: 5, skippedCount: 0, groupsCreatedCount: 2)
+        let summary = result.importSummary
+        #expect(summary.contains("2 new groups created"))
+        #expect(!summary.contains("reused"))
+    }
+
+    @Test("Existing groups reused line appears with correct count")
+    func groupsReused() {
+        let result = OPMLImportResult(addedCount: 3, skippedCount: 0, groupsReusedCount: 1)
+        let summary = result.importSummary
+        #expect(summary.contains("1 existing group reused"))
+        #expect(!summary.contains("created"))
+    }
+
+    @Test("Both created and reused groups appear on same bullet")
+    func groupsCreatedAndReused() {
+        let result = OPMLImportResult(addedCount: 5, skippedCount: 1, groupsCreatedCount: 2, groupsReusedCount: 1)
+        let summary = result.importSummary
+        #expect(summary.contains("2 new groups created, 1 existing group reused"))
+    }
+
+    @Test("Groups singular uses 'group' not 'groups'")
+    func groupsSingular() {
+        let result = OPMLImportResult(addedCount: 1, skippedCount: 0, groupsCreatedCount: 1, groupsReusedCount: 1)
+        let summary = result.importSummary
+        #expect(summary.contains("1 new group created"))
+        #expect(summary.contains("1 existing group reused"))
+    }
+
+    // MARK: - Error lines
+
+    @Test("Failed feeds shows actionable message")
+    func failedFeeds() {
+        let result = OPMLImportResult(addedCount: 3, skippedCount: 0, failedCount: 2)
+        let summary = result.importSummary
+        #expect(summary.contains("2 feeds couldn't be saved"))
+        #expect(summary.contains("try re-importing"))
+    }
+
+    @Test("Failed feeds singular uses 'feed' not 'feeds'")
+    func failedFeedsSingular() {
+        let result = OPMLImportResult(addedCount: 2, skippedCount: 0, failedCount: 1)
+        #expect(result.importSummary.contains("1 feed couldn't be saved"))
+    }
+
+    @Test("Failed group assignments shows actionable message")
+    func failedGroupAssignments() {
+        let result = OPMLImportResult(addedCount: 2, skippedCount: 0, groupsFailedCount: 1)
+        let summary = result.importSummary
+        #expect(summary.contains("1 group assignment failed"))
+        #expect(summary.contains("Settings logs"))
+    }
+
+    @Test("Failed group assignments plural uses 'assignments'")
+    func failedGroupAssignmentsPlural() {
+        let result = OPMLImportResult(addedCount: 1, skippedCount: 0, groupsFailedCount: 3)
+        #expect(result.importSummary.contains("3 group assignments failed"))
+    }
+
+    // MARK: - Realistic combination
+
+    @Test("Full result shows all sections in order")
+    func fullResult() {
+        let result = OPMLImportResult(
+            addedCount: 5,
+            skippedCount: 2,
+            failedCount: 1,
+            groupsCreatedCount: 2,
+            groupsReusedCount: 1,
+            groupsFailedCount: 1
+        )
+        let lines = result.importSummary.components(separatedBy: "\n")
+        #expect(lines.count == 6)
+        #expect(lines[0] == "Imported from OPML:")
+        #expect(lines[1].contains("5 new feeds added"))
+        #expect(lines[2].contains("2 duplicates skipped"))
+        #expect(lines[3].contains("2 new groups created, 1 existing group reused"))
+        #expect(lines[4].contains("1 feed couldn't be saved"))
+        #expect(lines[5].contains("1 group assignment failed"))
+    }
+
+    @Test("All-duplicates special case is not triggered when group failures also present")
+    func allDuplicatesWithGroupFailureNotSpecialCased() {
+        let result = OPMLImportResult(addedCount: 0, skippedCount: 3, groupsFailedCount: 1)
+        let summary = result.importSummary
+        // Should fall through to bulleted format, not the short "all feeds already in list" message
+        #expect(summary.hasPrefix("Imported from OPML:"))
+        #expect(summary.contains("3 duplicates skipped"))
+        #expect(summary.contains("group assignment failed"))
+    }
+}


### PR DESCRIPTION
## Summary
- Surfaces the existing `groupsCreatedCount` and `groupsReusedCount` fields in the post-import alert (they were tracked but never shown to the user)
- Replaces the single concatenated sentence with a multi-line bulleted summary starting with "Imported from OPML:"
- Error lines now include actionable guidance ("check the feed URL and try re-importing", "check Settings logs")
- Proper singular/plural handling throughout (e.g. "1 feed" vs "2 feeds", "1 group" vs "3 groups")
- The all-duplicates and empty-file special cases still work correctly

Closes #354

## Changes
- `RSSApp/Models/OPMLImportResult.swift` — added `importSummary: String` computed property; presentation logic now lives on the model that owns the data
- `RSSApp/Views/SettingsView.swift` — replaced `importResultMessage(_:)` private helper with a direct call to `result.importSummary`
- `RSSAppTests/Models/OPMLImportResultTests.swift` — 17 new tests covering special cases, each count type, singular/plural, and a full realistic combination

## Test plan
- [x] All 17 new `OPMLImportResultTests` pass
- [x] Full test suite passes with no regressions