### PR TITLE
feat: Round-trip htmlUrl (site URL) through OPML import and export (#355)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -25,7 +25,7 @@ RSSApp/
 │   ├── OPMLImportResult.swift           # OPML import outcome counts (added, skipped, groupsCreated, groupsReused, total)
 │   ├── PersistentArticle.swift         # @Model — persisted article with read/unread status, saved/bookmarked status, `updatedDate` + `wasUpdated` flag for content-update detection (issue #74), `displayedPublishedDate` computed helper, relationship to feed and content
 │   ├── PersistentArticleContent.swift  # @Model — cached extracted HTML/text content, relationship to article
-│   ├── PersistentFeed.swift            # @Model — persisted feed subscription with caching headers, icon URL, `iconBackgroundStyleRaw` (String) storage + typed `iconBackgroundStyle: FeedIconBackgroundStyle?` computed accessor for per-feed luminance-based tile classification (issue #342), `sortOrder` for user-customizable feed list ordering (issue #333), `firstFetchErrorDate` for streak-start tracking used by auto-skip (issue #326), cascade to articles and group memberships
+│   ├── PersistentFeed.swift            # @Model — persisted feed subscription with caching headers, icon URL, `iconBackgroundStyleRaw` (String) storage + typed `iconBackgroundStyle: FeedIconBackgroundStyle?` computed accessor for per-feed luminance-based tile classification (issue #342), `sortOrder` for user-customizable feed list ordering (issue #333), `firstFetchErrorDate` for streak-start tracking used by auto-skip (issue #326), `siteURL` for the user-facing website URL sourced from OPML `htmlUrl` (issue #355), cascade to articles and group memberships
 │   ├── PersistentFeedGroup.swift       # @Model — user-created feed group with name, sortOrder, cascade to memberships
 │   ├── PersistentFeedGroupMembership.swift # @Model — join model for many-to-many feed↔group relationship; unique (feed, group) enforced at application layer
 │   ├── AtomAlternatePrompt.swift       # Shared value struct — discovered Atom URL + the already-fetched RSS feed for the "Keep RSS" path; failing init enforces "RSS format + distinct URLs" invariants that `AtomDiscoveryService` and the view-model call sites already establish
@@ -159,7 +159,7 @@ RSSAppTests/
 │   ├── HTMLUtilitiesTests.swift        # Tag stripping, entity decoding, image extraction, og:image extraction
 │   ├── UserDefaultsMigrationTests.swift # Migration from UserDefaults to SwiftData, idempotency, ID preservation
 │   ├── KeychainServiceTests.swift      # Save/load/delete/overwrite roundtrips
-│   ├── OPMLServiceTests.swift          # Parse flat/nested/empty OPML, generate + round-trip, XML escaping
+│   ├── OPMLServiceTests.swift          # Parse flat/nested/empty OPML, generate + round-trip, XML escaping, htmlUrl/siteURL round-trip (issue #355)
 │   ├── BackgroundImageDownloadSettingsTests.swift # WiFi-only default, set/get roundtrip, UserDefaults persistence
 │   ├── BackgroundRefreshSettingsTests.swift # Defaults match issue #76 spec (On, 1 hour, Wi-Fi Only, Charging Only), setter round-trips for each of the four preferences, corrupt-value fallback for unknown interval/network/power raw values. Serialized suite to avoid racing on `UserDefaults.standard`
 │   ├── BackgroundRefreshSchedulerTests.swift # Matrix tests pinning `decideTaskType(interval:network:power:)`: unconstrained short (15 min / 1 hr with any network + any power) → appRefresh; any Wi-Fi Only or Charging Only constraint → processing; long intervals (2/8 hr) → processing even without constraints
@@ -296,6 +296,7 @@ RSSAppApp (@main)
 | `OPMLFeedEntry` intermediate type | Decouples OPML parser from persistence model; OPML data lacks `id`/`addedDate` fields |
 | Manual XML generation for OPML export | `XMLDocument` is macOS-only; string building with XML escaping is sufficient for the simple OPML structure |
 | OPML import accepts outlines without `type="rss"` | Real-world OPML files often omit the type attribute; any outline with a valid `xmlUrl` is treated as a feed |
+| `siteURL` sourced from OPML only; not backfilled from RSS/Atom `<link>` | `FeedRefreshService` already uses `fetchResult.feed.link` (RSS/Atom `<link>` channel field) and `feed.feedURL.siteRoot` as heuristics for icon resolution, but does not persist them as `siteURL`. These are ephemeral heuristics computed per-refresh. `siteURL` on `PersistentFeed` exclusively holds the explicit user-facing website URL from OPML `htmlUrl` — an authoritative publisher-supplied value that should only be written during import (issue #355). Mixing derived heuristics into the canonical field would silently overwrite the OPML value on every refresh |
 | Feed title fetched at add-time | Validates the URL is a real feed; better UX than requiring manual title entry |
 | `FeedViewModel` with cache-first loading | Shows cached articles immediately from SwiftData, then fetches from network and upserts; enables offline browsing |
 | Home screen as app root | Provides meta-groups (All Articles, Unread Articles, Saved Articles, All Feeds) above the feed list; pushes `FeedListView` via NavigationStack rather than replacing it |

--- a/RSSApp/Models/ModelConversion.swift
+++ b/RSSApp/Models/ModelConversion.swift
@@ -10,6 +10,7 @@ extension PersistentFeed {
             title: subscribedFeed.title,
             feedURL: subscribedFeed.url,
             feedDescription: subscribedFeed.feedDescription,
+            siteURL: subscribedFeed.siteURL,
             addedDate: subscribedFeed.addedDate,
             lastFetchError: subscribedFeed.lastFetchError,
             lastFetchErrorDate: subscribedFeed.lastFetchErrorDate
@@ -22,6 +23,7 @@ extension PersistentFeed {
             title: title,
             url: feedURL,
             feedDescription: feedDescription,
+            siteURL: siteURL,
             addedDate: addedDate,
             lastFetchError: lastFetchError,
             lastFetchErrorDate: lastFetchErrorDate

--- a/RSSApp/Models/PersistentFeed.swift
+++ b/RSSApp/Models/PersistentFeed.swift
@@ -31,6 +31,15 @@ final class PersistentFeed {
     var etag: String?
     var lastModifiedHeader: String?
 
+    // MARK: - Site URL
+
+    /// The feed's user-facing website URL, sourced from the `htmlUrl` attribute in
+    /// OPML files. Distinct from `feedURL` (the XML endpoint). `nil` for feeds added
+    /// before this field was introduced — SwiftData's implicit schema migration
+    /// initializes the new optional column to `nil` for existing rows on the first
+    /// launch after the schema bump.
+    var siteURL: URL?
+
     // MARK: - Icon
 
     var iconURL: URL?
@@ -80,6 +89,7 @@ final class PersistentFeed {
         title: String,
         feedURL: URL,
         feedDescription: String = "",
+        siteURL: URL? = nil,
         addedDate: Date = Date(),
         sortOrder: Int = 0,
         lastRefreshDate: Date? = nil,
@@ -95,6 +105,7 @@ final class PersistentFeed {
         self.title = title
         self.feedURL = feedURL
         self.feedDescription = feedDescription
+        self.siteURL = siteURL
         self.addedDate = addedDate
         self.sortOrder = sortOrder
         self.lastRefreshDate = lastRefreshDate

--- a/RSSApp/Models/SubscribedFeed.swift
+++ b/RSSApp/Models/SubscribedFeed.swift
@@ -33,14 +33,16 @@ struct SubscribedFeed: Identifiable, Hashable, Codable, Sendable {
     func updatingMetadata(title: String, feedDescription: String) -> SubscribedFeed {
         SubscribedFeed(
             id: id, title: title, url: url,
-            feedDescription: feedDescription, addedDate: addedDate
+            feedDescription: feedDescription, siteURL: siteURL,
+            addedDate: addedDate
         )
     }
 
     func updatingError(_ message: String) -> SubscribedFeed {
         SubscribedFeed(
             id: id, title: title, url: url,
-            feedDescription: feedDescription, addedDate: addedDate,
+            feedDescription: feedDescription, siteURL: siteURL,
+            addedDate: addedDate,
             lastFetchError: message, lastFetchErrorDate: Date()
         )
     }
@@ -48,7 +50,8 @@ struct SubscribedFeed: Identifiable, Hashable, Codable, Sendable {
     func updatingURL(_ newURL: URL) -> SubscribedFeed {
         SubscribedFeed(
             id: id, title: title, url: newURL,
-            feedDescription: feedDescription, addedDate: addedDate
+            feedDescription: feedDescription, siteURL: siteURL,
+            addedDate: addedDate
         )
     }
 }

--- a/RSSApp/Models/SubscribedFeed.swift
+++ b/RSSApp/Models/SubscribedFeed.swift
@@ -5,6 +5,7 @@ struct SubscribedFeed: Identifiable, Hashable, Codable, Sendable {
     let title: String
     let url: URL
     let feedDescription: String
+    let siteURL: URL?
     let addedDate: Date
     let lastFetchError: String?
     let lastFetchErrorDate: Date?
@@ -14,6 +15,7 @@ struct SubscribedFeed: Identifiable, Hashable, Codable, Sendable {
         title: String,
         url: URL,
         feedDescription: String,
+        siteURL: URL? = nil,
         addedDate: Date,
         lastFetchError: String? = nil,
         lastFetchErrorDate: Date? = nil
@@ -22,6 +24,7 @@ struct SubscribedFeed: Identifiable, Hashable, Codable, Sendable {
         self.title = title
         self.url = url
         self.feedDescription = feedDescription
+        self.siteURL = siteURL
         self.addedDate = addedDate
         self.lastFetchError = lastFetchError
         self.lastFetchErrorDate = lastFetchErrorDate

--- a/RSSApp/Services/OPMLService.swift
+++ b/RSSApp/Services/OPMLService.swift
@@ -97,6 +97,9 @@ struct OPMLService: OPMLServing {
             for feed in feeds {
                 xml += "      <outline text=\"\(xmlEscape(feed.title))\" type=\"rss\""
                 xml += " xmlUrl=\"\(xmlEscape(feed.url.absoluteString))\""
+                if let siteURL = feed.siteURL {
+                    xml += " htmlUrl=\"\(xmlEscape(siteURL.absoluteString))\""
+                }
                 if !feed.feedDescription.isEmpty {
                     xml += " description=\"\(xmlEscape(feed.feedDescription))\""
                 }
@@ -109,6 +112,9 @@ struct OPMLService: OPMLServing {
         for feed in ungroupedFeeds {
             xml += "    <outline text=\"\(xmlEscape(feed.title))\" type=\"rss\""
             xml += " xmlUrl=\"\(xmlEscape(feed.url.absoluteString))\""
+            if let siteURL = feed.siteURL {
+                xml += " htmlUrl=\"\(xmlEscape(siteURL.absoluteString))\""
+            }
             if !feed.feedDescription.isEmpty {
                 xml += " description=\"\(xmlEscape(feed.feedDescription))\""
             }

--- a/RSSApp/ViewModels/FeedListViewModel.swift
+++ b/RSSApp/ViewModels/FeedListViewModel.swift
@@ -216,6 +216,7 @@ final class FeedListViewModel {
                     title: entry.title,
                     feedURL: entry.feedURL,
                     feedDescription: entry.description,
+                    siteURL: entry.siteURL,
                     sortOrder: nextFeedSortOrder
                 )
                 do {

--- a/RSSAppTests/Helpers/TestFixtures.swift
+++ b/RSSAppTests/Helpers/TestFixtures.swift
@@ -729,6 +729,7 @@ enum TestFixtures {
         title: String = "Test Feed",
         url: URL = URL(string: "https://example.com/feed")!,
         feedDescription: String = "A test feed",
+        siteURL: URL? = nil,
         addedDate: Date = Date(timeIntervalSince1970: 1_711_800_000),
         lastFetchError: String? = nil,
         lastFetchErrorDate: Date? = nil
@@ -738,6 +739,7 @@ enum TestFixtures {
             title: title,
             url: url,
             feedDescription: feedDescription,
+            siteURL: siteURL,
             addedDate: addedDate,
             lastFetchError: lastFetchError,
             lastFetchErrorDate: lastFetchErrorDate
@@ -785,6 +787,7 @@ enum TestFixtures {
         title: String = "Test Feed",
         feedURL: URL = URL(string: "https://example.com/feed")!,
         feedDescription: String = "A test feed",
+        siteURL: URL? = nil,
         addedDate: Date = Date(timeIntervalSince1970: 1_711_800_000),
         sortOrder: Int = 0,
         iconURL: URL? = nil,
@@ -798,6 +801,7 @@ enum TestFixtures {
             title: title,
             feedURL: feedURL,
             feedDescription: feedDescription,
+            siteURL: siteURL,
             addedDate: addedDate,
             sortOrder: sortOrder,
             iconURL: iconURL,

--- a/RSSAppTests/Models/SubscribedFeedTests.swift
+++ b/RSSAppTests/Models/SubscribedFeedTests.swift
@@ -5,11 +5,13 @@ import Foundation
 @Suite("SubscribedFeed Tests")
 struct SubscribedFeedTests {
 
-    @Test("updatingMetadata preserves id, url, and addedDate")
+    @Test("updatingMetadata preserves id, url, siteURL, and addedDate")
     func updatingMetadataPreservesIdentity() {
+        let siteURL = URL(string: "https://example.com")!
         let original = TestFixtures.makeSubscribedFeed(
             title: "Old Title",
-            feedDescription: "Old Description"
+            feedDescription: "Old Description",
+            siteURL: siteURL
         )
         let updated = original.updatingMetadata(
             title: "New Title",
@@ -18,6 +20,7 @@ struct SubscribedFeedTests {
 
         #expect(updated.id == original.id)
         #expect(updated.url == original.url)
+        #expect(updated.siteURL == siteURL)
         #expect(updated.addedDate == original.addedDate)
         #expect(updated.title == "New Title")
         #expect(updated.feedDescription == "New Description")
@@ -35,20 +38,24 @@ struct SubscribedFeedTests {
         #expect(updated.lastFetchErrorDate == nil)
     }
 
-    @Test("updatingError sets error fields")
+    @Test("updatingError sets error fields and preserves siteURL")
     func updatingErrorSetsFields() {
-        let feed = TestFixtures.makeSubscribedFeed()
+        let siteURL = URL(string: "https://example.com")!
+        let feed = TestFixtures.makeSubscribedFeed(siteURL: siteURL)
         let updated = feed.updatingError("HTTP 404")
 
         #expect(updated.lastFetchError == "HTTP 404")
         #expect(updated.lastFetchErrorDate != nil)
         #expect(updated.id == feed.id)
         #expect(updated.url == feed.url)
+        #expect(updated.siteURL == siteURL)
     }
 
-    @Test("updatingURL changes URL and clears error")
+    @Test("updatingURL changes URL, clears error, and preserves siteURL")
     func updatingURLChangesAndClearsError() {
+        let siteURL = URL(string: "https://example.com")!
         let feed = TestFixtures.makeSubscribedFeed(
+            siteURL: siteURL,
             lastFetchError: "HTTP 404",
             lastFetchErrorDate: Date()
         )
@@ -60,6 +67,7 @@ struct SubscribedFeedTests {
         #expect(updated.lastFetchErrorDate == nil)
         #expect(updated.id == feed.id)
         #expect(updated.title == feed.title)
+        #expect(updated.siteURL == siteURL)
     }
 
     @Test("Codable roundtrip preserves error fields")

--- a/RSSAppTests/Services/OPMLServiceTests.swift
+++ b/RSSAppTests/Services/OPMLServiceTests.swift
@@ -510,4 +510,78 @@ struct OPMLServiceTests {
         let entries = try service.parseOPML(data)
         #expect(entries[0].groupName == "Tech & Science")
     }
+
+    // MARK: - htmlUrl / siteURL round-trip
+
+    @Test("generates htmlUrl attribute when feed has a siteURL")
+    func generatesHtmlUrlWhenSiteURLPresent() throws {
+        let feeds = [
+            TestFixtures.makeSubscribedFeed(
+                title: "Feed With Site",
+                url: URL(string: "https://example.com/feed")!,
+                siteURL: URL(string: "https://example.com")
+            ),
+        ]
+
+        let data = try service.generateOPML(from: feeds)
+        let xml = String(data: data, encoding: .utf8)!
+
+        #expect(xml.contains("htmlUrl=\"https://example.com\""))
+    }
+
+    @Test("omits htmlUrl attribute when feed has no siteURL")
+    func omitsHtmlUrlWhenSiteURLAbsent() throws {
+        let feeds = [
+            TestFixtures.makeSubscribedFeed(
+                title: "Feed Without Site",
+                url: URL(string: "https://example.com/feed")!,
+                siteURL: nil
+            ),
+        ]
+
+        let data = try service.generateOPML(from: feeds)
+        let xml = String(data: data, encoding: .utf8)!
+
+        #expect(!xml.contains("htmlUrl="))
+    }
+
+    @Test("siteURL round-trips through generate then parse")
+    func siteURLRoundTrips() throws {
+        let siteURL = URL(string: "https://example.com")!
+        let feeds = [
+            TestFixtures.makeSubscribedFeed(
+                title: "Round-Trip Feed",
+                url: URL(string: "https://example.com/feed")!,
+                siteURL: siteURL
+            ),
+        ]
+
+        let data = try service.generateOPML(from: feeds)
+        let entries = try service.parseOPML(data)
+
+        #expect(entries.count == 1)
+        #expect(entries[0].siteURL == siteURL)
+    }
+
+    @Test("siteURL round-trips for a feed nested in a category")
+    func siteURLRoundTripsInGroupedFeed() throws {
+        let siteURL = URL(string: "https://tech.com")!
+        let groupedFeeds = [
+            GroupedFeed(
+                feed: TestFixtures.makeSubscribedFeed(
+                    title: "Tech Feed",
+                    url: URL(string: "https://tech.com/feed")!,
+                    siteURL: siteURL
+                ),
+                groupNames: ["Tech"]
+            ),
+        ]
+
+        let data = try service.generateOPML(from: groupedFeeds)
+        let entries = try service.parseOPML(data)
+
+        #expect(entries.count == 1)
+        #expect(entries[0].siteURL == siteURL)
+        #expect(entries[0].groupName == "Tech")
+    }
 }

--- a/RSSAppTests/ViewModels/FeedListViewModelTests.swift
+++ b/RSSAppTests/ViewModels/FeedListViewModelTests.swift
@@ -827,6 +827,71 @@ struct FeedListViewModelTests {
         #expect(viewModel.opmlImportResult?.addedCount == 1)
     }
 
+    @Test("importOPML populates siteURL on new feed from OPML entry htmlUrl")
+    @MainActor
+    func importOPMLPopulatesSiteURL() {
+        let mockPersistence = MockFeedPersistenceService()
+        let mockOPML = MockOPMLService()
+        let siteURL = URL(string: "https://example.com")!
+        mockOPML.entriesToReturn = [
+            OPMLFeedEntry(
+                title: "Example Feed",
+                feedURL: URL(string: "https://example.com/feed")!,
+                siteURL: siteURL,
+                description: ""
+            ),
+        ]
+
+        let viewModel = Self.makeViewModel(persistence: mockPersistence, opmlService: mockOPML)
+        viewModel.importOPML(from: Data())
+
+        #expect(viewModel.feeds.count == 1)
+        #expect(viewModel.feeds[0].siteURL == siteURL)
+    }
+
+    @Test("importOPML leaves siteURL nil when OPML entry has no htmlUrl")
+    @MainActor
+    func importOPMLLeavesSiteURLNilWhenAbsent() {
+        let mockPersistence = MockFeedPersistenceService()
+        let mockOPML = MockOPMLService()
+        mockOPML.entriesToReturn = [
+            OPMLFeedEntry(
+                title: "No Site Feed",
+                feedURL: URL(string: "https://example.com/feed")!,
+                siteURL: nil,
+                description: ""
+            ),
+        ]
+
+        let viewModel = Self.makeViewModel(persistence: mockPersistence, opmlService: mockOPML)
+        viewModel.importOPML(from: Data())
+
+        #expect(viewModel.feeds.count == 1)
+        #expect(viewModel.feeds[0].siteURL == nil)
+    }
+
+    @Test("exportOPML passes siteURL through toSubscribedFeed conversion")
+    @MainActor
+    func exportOPMLPassesSiteURL() {
+        let siteURL = URL(string: "https://example.com")!
+        let mockPersistence = MockFeedPersistenceService()
+        mockPersistence.feeds = [
+            TestFixtures.makePersistentFeed(
+                feedURL: URL(string: "https://example.com/feed")!,
+                siteURL: siteURL
+            ),
+        ]
+        let mockOPML = MockOPMLService()
+        mockOPML.dataToReturn = Data("opml-output".utf8)
+
+        let viewModel = Self.makeViewModel(persistence: mockPersistence, opmlService: mockOPML)
+        viewModel.loadFeeds()
+        viewModel.exportOPML()
+
+        let generatedFeed = mockOPML.lastGeneratedGroupedFeeds?.first?.feed
+        #expect(generatedFeed?.siteURL == siteURL)
+    }
+
     @Test("importOPML from URL sets importExportErrorMessage on file read failure")
     @MainActor
     func importOPMLFromURLSetsImportExportErrorOnReadFailure() {


### PR DESCRIPTION
## Summary
- Adds `siteURL: URL?` to `PersistentFeed` and `SubscribedFeed` so the OPML `htmlUrl` attribute (the feed's user-facing website URL) is stored persistently rather than silently discarded on import
- OPML import now populates `siteURL` from `OPMLFeedEntry.siteURL` when creating new `PersistentFeed` instances
- OPML export now emits `htmlUrl="..."` when a feed has a non-nil `siteURL`, enabling full round-trip fidelity for users migrating between RSS apps
- `siteURL` is not backfilled from the RSS/Atom `<link>` channel field or `feedURL.siteRoot` — those are ephemeral icon-resolution heuristics, not the authoritative OPML-supplied value (documented in ARCHITECTURE.md)
- SwiftData's implicit schema migration handles the new optional column with a `nil` default for existing rows — no explicit migration step needed
- Fixes `siteURL` being silently dropped to `nil` by `updatingMetadata`, `updatingError`, and `updatingURL` on `SubscribedFeed`

## Test plan
- [x] Built successfully for iOS 26 Simulator
- [x] All 29 OPMLServiceTests pass, including 4 new tests:
  - `generatesHtmlUrlWhenSiteURLPresent` — export emits `htmlUrl` attribute
  - `omitsHtmlUrlWhenSiteURLAbsent` — export omits `htmlUrl` when nil
  - `siteURLRoundTrips` — flat export round-trip preserves `siteURL`
  - `siteURLRoundTripsInGroupedFeed` — grouped export round-trip preserves `siteURL`
- [x] 3 new `FeedListViewModelTests`:
  - `importOPMLPopulatesSiteURL` — import sets `siteURL` from OPML entry
  - `importOPMLLeavesSiteURLNilWhenAbsent` — import leaves `siteURL` nil when no `htmlUrl`
  - `exportOPMLPassesSiteURL` — export passes `siteURL` through `toSubscribedFeed()` conversion
- [x] Updated 3 `SubscribedFeedTests` to assert `siteURL` is preserved by all `updating*` methods
- [x] Existing tests unaffected (all factory methods have `siteURL: nil` defaults)
- [x] Full test suite passes

Closes #355
Closes #376