### PR TITLE
feat: Track and report OPML feed entries skipped due to invalid xmlUrl

### DIFF
--- a/RSSApp/Models/OPMLImportResult.swift
+++ b/RSSApp/Models/OPMLImportResult.swift
@@ -4,15 +4,17 @@ struct OPMLImportResult: Sendable, Equatable {
     let addedCount: Int
     let skippedCount: Int
     let failedCount: Int
+    let parseSkippedCount: Int
     let groupsCreatedCount: Int
     let groupsReusedCount: Int
     let groupsFailedCount: Int
-    var totalInFile: Int { addedCount + skippedCount + failedCount }
+    var totalInFile: Int { addedCount + skippedCount + failedCount + parseSkippedCount }
 
     init(
         addedCount: Int,
         skippedCount: Int,
         failedCount: Int = 0,
+        parseSkippedCount: Int = 0,
         groupsCreatedCount: Int = 0,
         groupsReusedCount: Int = 0,
         groupsFailedCount: Int = 0
@@ -20,6 +22,7 @@ struct OPMLImportResult: Sendable, Equatable {
         self.addedCount = addedCount
         self.skippedCount = skippedCount
         self.failedCount = failedCount
+        self.parseSkippedCount = parseSkippedCount
         self.groupsCreatedCount = groupsCreatedCount
         self.groupsReusedCount = groupsReusedCount
         self.groupsFailedCount = groupsFailedCount
@@ -27,7 +30,7 @@ struct OPMLImportResult: Sendable, Equatable {
 
     /// A user-facing multi-line bulleted summary of the import result.
     var importSummary: String {
-        if addedCount == 0 && skippedCount > 0 && failedCount == 0
+        if addedCount == 0 && skippedCount > 0 && failedCount == 0 && parseSkippedCount == 0
             && groupsCreatedCount == 0 && groupsReusedCount == 0 && groupsFailedCount == 0 {
             return "All \(skippedCount) \(skippedCount == 1 ? "feed was" : "feeds were") already in your list."
         }
@@ -43,6 +46,11 @@ struct OPMLImportResult: Sendable, Equatable {
         }
         if skippedCount > 0 {
             lines.append("• \(skippedCount) \(skippedCount == 1 ? "duplicate" : "duplicates") skipped")
+        }
+        if parseSkippedCount > 0 {
+            lines.append(
+                "• \(parseSkippedCount) \(parseSkippedCount == 1 ? "entry" : "entries") in the file had an invalid feed URL and \(parseSkippedCount == 1 ? "was" : "were") skipped"
+            )
         }
 
         let hasGroupActivity = groupsCreatedCount > 0 || groupsReusedCount > 0

--- a/RSSApp/Services/OPMLService.swift
+++ b/RSSApp/Services/OPMLService.swift
@@ -13,8 +13,16 @@ struct GroupedFeed: Sendable {
     let groupNames: [String]
 }
 
+/// The result of parsing an OPML file, including the parsed feed entries and
+/// the number of feed outlines that were silently skipped due to invalid xmlUrl values.
+struct OPMLParseResult: Sendable {
+    let entries: [OPMLFeedEntry]
+    /// Number of feed outlines whose `xmlUrl` attribute could not be parsed as a valid URL.
+    let parseSkippedCount: Int
+}
+
 protocol OPMLServing: Sendable {
-    func parseOPML(_ data: Data) throws -> [OPMLFeedEntry]
+    func parseOPML(_ data: Data) throws -> OPMLParseResult
     func generateOPML(from feeds: [SubscribedFeed]) throws -> Data
     func generateOPML(from groupedFeeds: [GroupedFeed]) throws -> Data
 }
@@ -23,7 +31,7 @@ struct OPMLService: OPMLServing {
 
     private static let logger = Logger(category: "OPMLService")
 
-    func parseOPML(_ data: Data) throws -> [OPMLFeedEntry] {
+    func parseOPML(_ data: Data) throws -> OPMLParseResult {
         Self.logger.debug("parseOPML() called with \(data.count, privacy: .public) bytes")
 
         let delegate = OPMLParserDelegate()
@@ -43,8 +51,8 @@ struct OPMLService: OPMLServing {
             throw OPMLError.noBodyFound
         }
 
-        Self.logger.notice("OPML parsed: \(delegate.entries.count, privacy: .public) feed entries")
-        return delegate.entries
+        Self.logger.notice("OPML parsed: \(delegate.entries.count, privacy: .public) feed entries, \(delegate.parseSkippedCount, privacy: .public) skipped due to invalid xmlUrl")
+        return OPMLParseResult(entries: delegate.entries, parseSkippedCount: delegate.parseSkippedCount)
     }
 
     func generateOPML(from feeds: [SubscribedFeed]) throws -> Data {
@@ -159,6 +167,8 @@ private final class OPMLParserDelegate: NSObject, XMLParserDelegate, @unchecked 
 
     var foundBody = false
     var entries: [OPMLFeedEntry] = []
+    /// Number of feed outlines whose `xmlUrl` attribute could not be parsed as a valid URL.
+    var parseSkippedCount = 0
 
     /// Stack of category names representing the current nesting path.
     /// Only `<outline>` elements inside `<body>` that lack `xmlUrl` are
@@ -195,6 +205,7 @@ private final class OPMLParserDelegate: NSObject, XMLParserDelegate, @unchecked 
                 // This is a feed outline.
                 guard let feedURL = URL(string: xmlUrlString) else {
                     Self.logger.warning("Skipped outline with unparseable xmlUrl: '\(xmlUrlString, privacy: .public)'")
+                    parseSkippedCount += 1
                     outlinePushedCategory.append(false)
                     return
                 }

--- a/RSSApp/ViewModels/FeedListViewModel.swift
+++ b/RSSApp/ViewModels/FeedListViewModel.swift
@@ -147,18 +147,20 @@ final class FeedListViewModel {
         importExportErrorMessage = nil
         Self.logger.debug("importOPML() called with \(data.count, privacy: .public) bytes")
 
-        let entries: [OPMLFeedEntry]
+        let parseResult: OPMLParseResult
         do {
-            entries = try opmlService.parseOPML(data)
+            parseResult = try opmlService.parseOPML(data)
         } catch {
             importExportErrorMessage = "Unable to import feeds. The file may be invalid."
             Self.logger.error("OPML parse failed: \(error, privacy: .public)")
             return
         }
 
+        let entries = parseResult.entries
         var addedCount = 0
         var skippedCount = 0
         var failedCount = 0
+        let parseSkippedCount = parseResult.parseSkippedCount
         var groupsCreatedCount = 0
         var groupsReusedCount = 0
         var groupsFailedCount = 0
@@ -275,12 +277,13 @@ final class FeedListViewModel {
             addedCount: addedCount,
             skippedCount: skippedCount,
             failedCount: failedCount,
+            parseSkippedCount: parseSkippedCount,
             groupsCreatedCount: groupsCreatedCount,
             groupsReusedCount: groupsReusedCount,
             groupsFailedCount: groupsFailedCount
         )
         importExportErrorMessage = nil
-        Self.logger.notice("OPML import: added \(addedCount, privacy: .public), skipped \(skippedCount, privacy: .public), failed \(failedCount, privacy: .public), groups created \(groupsCreatedCount, privacy: .public), groups reused \(groupsReusedCount, privacy: .public), groups failed \(groupsFailedCount, privacy: .public)")
+        Self.logger.notice("OPML import: added \(addedCount, privacy: .public), skipped \(skippedCount, privacy: .public), failed \(failedCount, privacy: .public), parse-skipped \(parseSkippedCount, privacy: .public), groups created \(groupsCreatedCount, privacy: .public), groups reused \(groupsReusedCount, privacy: .public), groups failed \(groupsFailedCount, privacy: .public)")
     }
 
     func exportOPML() {

--- a/RSSApp/Views/SettingsView.swift
+++ b/RSSApp/Views/SettingsView.swift
@@ -277,8 +277,6 @@ struct ImportExportView: View {
         }
     }
 
-    // MARK: - Helpers
-
     private func handleFileImport(_ result: Result<URL, any Error>) {
         switch result {
         case .success(let url):

--- a/RSSAppTests/Mocks/MockOPMLService.swift
+++ b/RSSAppTests/Mocks/MockOPMLService.swift
@@ -3,13 +3,14 @@ import Foundation
 
 final class MockOPMLService: OPMLServing, @unchecked Sendable {
     var entriesToReturn: [OPMLFeedEntry] = []
+    var parseSkippedCountToReturn: Int = 0
     var dataToReturn = Data()
     var errorToThrow: (any Error)?
     var lastGeneratedGroupedFeeds: [GroupedFeed]?
 
-    func parseOPML(_ data: Data) throws -> [OPMLFeedEntry] {
+    func parseOPML(_ data: Data) throws -> OPMLParseResult {
         if let error = errorToThrow { throw error }
-        return entriesToReturn
+        return OPMLParseResult(entries: entriesToReturn, parseSkippedCount: parseSkippedCountToReturn)
     }
 
     func generateOPML(from feeds: [SubscribedFeed]) throws -> Data {

--- a/RSSAppTests/Models/OPMLImportResultTests.swift
+++ b/RSSAppTests/Models/OPMLImportResultTests.swift
@@ -57,6 +57,38 @@ struct OPMLImportResultTests {
         #expect(result.importSummary.contains("1 duplicate skipped"))
     }
 
+    // MARK: - parseSkippedCount wording
+
+    @Test("Singular parse-skipped uses 'entry' and 'was'")
+    func parseSkippedSingular() {
+        let result = OPMLImportResult(addedCount: 2, skippedCount: 0, parseSkippedCount: 1)
+        let summary = result.importSummary
+        #expect(summary.contains("1 entry"))
+        #expect(summary.contains("was skipped"))
+    }
+
+    @Test("Plural parse-skipped uses 'entries' and 'were'")
+    func parseSkippedPlural() {
+        let result = OPMLImportResult(addedCount: 0, skippedCount: 0, parseSkippedCount: 3)
+        let summary = result.importSummary
+        #expect(summary.hasPrefix("Imported from OPML:"))
+        #expect(summary.contains("3 entries"))
+        #expect(summary.contains("were skipped"))
+    }
+
+    @Test("All-duplicates fast path does not fire when parseSkippedCount > 0")
+    func allDuplicatesFastPathBlockedByParseSkip() {
+        // addedCount == 0, skippedCount > 0, parseSkippedCount == 1
+        // The all-duplicates guard must not trigger; summary must describe the parse-skip.
+        let result = OPMLImportResult(addedCount: 0, skippedCount: 2, parseSkippedCount: 1)
+        let summary = result.importSummary
+        #expect(!summary.hasPrefix("All"))
+        #expect(summary.hasPrefix("Imported from OPML:"))
+        #expect(summary.contains("invalid feed URL"))
+        #expect(summary.contains("1 entry"))
+        #expect(summary.contains("was skipped"))
+    }
+
     // MARK: - Group counts
 
     @Test("New groups created line appears with correct count")
@@ -120,7 +152,7 @@ struct OPMLImportResultTests {
         #expect(result.importSummary.contains("3 group assignments failed"))
     }
 
-    // MARK: - Realistic combination
+    // MARK: - Realistic combinations
 
     @Test("Full result shows all sections in order")
     func fullResult() {
@@ -146,7 +178,6 @@ struct OPMLImportResultTests {
     func allDuplicatesWithGroupFailureNotSpecialCased() {
         let result = OPMLImportResult(addedCount: 0, skippedCount: 3, groupsFailedCount: 1)
         let summary = result.importSummary
-        // Should fall through to bulleted format, not the short "all feeds already in list" message
         #expect(summary.hasPrefix("Imported from OPML:"))
         #expect(summary.contains("3 duplicates skipped"))
         #expect(summary.contains("group assignment failed"))

--- a/RSSAppTests/Services/OPMLServiceTests.swift
+++ b/RSSAppTests/Services/OPMLServiceTests.swift
@@ -608,10 +608,10 @@ struct OPMLServiceTests {
         ]
 
         let data = try service.generateOPML(from: feeds)
-        let entries = try service.parseOPML(data)
+        let result = try service.parseOPML(data)
 
-        #expect(entries.count == 1)
-        #expect(entries[0].siteURL == siteURL)
+        #expect(result.entries.count == 1)
+        #expect(result.entries[0].siteURL == siteURL)
     }
 
     @Test("siteURL round-trips for a feed nested in a category")
@@ -629,10 +629,10 @@ struct OPMLServiceTests {
         ]
 
         let data = try service.generateOPML(from: groupedFeeds)
-        let entries = try service.parseOPML(data)
+        let result = try service.parseOPML(data)
 
-        #expect(entries.count == 1)
-        #expect(entries[0].siteURL == siteURL)
-        #expect(entries[0].groupName == "Tech")
+        #expect(result.entries.count == 1)
+        #expect(result.entries[0].siteURL == siteURL)
+        #expect(result.entries[0].groupName == "Tech")
     }
 }

--- a/RSSAppTests/Services/OPMLServiceTests.swift
+++ b/RSSAppTests/Services/OPMLServiceTests.swift
@@ -12,7 +12,7 @@ struct OPMLServiceTests {
     @Test("parses simple flat OPML with three feeds")
     func parsesSimpleOPML() throws {
         let data = Data(TestFixtures.sampleOPML.utf8)
-        let entries = try service.parseOPML(data)
+        let entries = try service.parseOPML(data).entries
 
         #expect(entries.count == 3)
 
@@ -38,7 +38,7 @@ struct OPMLServiceTests {
     @Test("parses nested OPML with category group names")
     func parsesNestedOPML() throws {
         let data = Data(TestFixtures.nestedOPML.utf8)
-        let entries = try service.parseOPML(data)
+        let entries = try service.parseOPML(data).entries
 
         #expect(entries.count == 3)
         #expect(entries[0].title == "Ars Technica")
@@ -62,7 +62,7 @@ struct OPMLServiceTests {
               </body>
             </opml>
             """
-        let entries = try service.parseOPML(Data(opml.utf8))
+        let entries = try service.parseOPML(Data(opml.utf8)).entries
 
         #expect(entries.count == 1)
         #expect(entries[0].title == "Real Feed")
@@ -79,7 +79,7 @@ struct OPMLServiceTests {
               </body>
             </opml>
             """
-        let entries = try service.parseOPML(Data(opml.utf8))
+        let entries = try service.parseOPML(Data(opml.utf8)).entries
 
         #expect(entries.count == 1)
         #expect(entries[0].title == "https://example.com/feed")
@@ -96,7 +96,7 @@ struct OPMLServiceTests {
               </body>
             </opml>
             """
-        let entries = try service.parseOPML(Data(opml.utf8))
+        let entries = try service.parseOPML(Data(opml.utf8)).entries
 
         #expect(entries[0].title == "Title Attr Feed")
     }
@@ -122,7 +122,7 @@ struct OPMLServiceTests {
     @Test("parses empty body and returns empty array")
     func parsesEmptyBody() throws {
         let data = Data(TestFixtures.emptyBodyOPML.utf8)
-        let entries = try service.parseOPML(data)
+        let entries = try service.parseOPML(data).entries
 
         #expect(entries.isEmpty)
     }
@@ -142,7 +142,7 @@ struct OPMLServiceTests {
               </body>
             </opml>
             """
-        let entries = try service.parseOPML(Data(opml.utf8))
+        let entries = try service.parseOPML(Data(opml.utf8)).entries
 
         #expect(entries.count == 1)
         #expect(entries[0].title == "Deep Feed")
@@ -163,10 +163,61 @@ struct OPMLServiceTests {
               </body>
             </opml>
             """
-        let entries = try service.parseOPML(Data(opml.utf8))
+        let entries = try service.parseOPML(Data(opml.utf8)).entries
 
         #expect(entries.count == 1)
         #expect(entries[0].title == "Body Feed")
+    }
+
+    // MARK: - Parse Skip Count
+
+    @Test("parseSkippedCount is zero when all entries have valid xmlUrl")
+    func parseSkippedCountIsZeroForValidEntries() throws {
+        let data = Data(TestFixtures.sampleOPML.utf8)
+        let result = try service.parseOPML(data)
+
+        #expect(result.entries.count == 3)
+        #expect(result.parseSkippedCount == 0)
+    }
+
+    @Test("parseSkippedCount reflects only entries with unparseable xmlUrl")
+    func parseSkippedCountMixedValidAndInvalid() throws {
+        // URLs containing spaces in the scheme are rejected by URL(string:).
+        let opml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <opml version="2.0">
+              <head><title>Test</title></head>
+              <body>
+                <outline text="Valid Feed" xmlUrl="https://valid.com/feed"/>
+                <outline text="Bad URL Feed" xmlUrl="ht tp://bad.example.com"/>
+                <outline text="Another Valid" xmlUrl="https://another.com/feed"/>
+                <outline text="Also Bad" xmlUrl="ht tp://also-bad.example.com"/>
+              </body>
+            </opml>
+            """
+        let result = try service.parseOPML(Data(opml.utf8))
+
+        #expect(result.entries.count == 2)
+        #expect(result.parseSkippedCount == 2)
+    }
+
+    @Test("parseSkippedCount equals total outlines when every entry is invalid")
+    func parseSkippedCountAllInvalid() throws {
+        // URLs containing spaces in the scheme are rejected by URL(string:).
+        let opml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <opml version="2.0">
+              <head><title>Test</title></head>
+              <body>
+                <outline text="Bad Feed 1" xmlUrl="ht tp://bad1.example.com"/>
+                <outline text="Bad Feed 2" xmlUrl="ht tp://bad2.example.com"/>
+              </body>
+            </opml>
+            """
+        let result = try service.parseOPML(Data(opml.utf8))
+
+        #expect(result.entries.isEmpty)
+        #expect(result.parseSkippedCount == 2)
     }
 
     // MARK: - Generation
@@ -187,7 +238,7 @@ struct OPMLServiceTests {
         ]
 
         let data = try service.generateOPML(from: feeds)
-        let entries = try service.parseOPML(data)
+        let entries = try service.parseOPML(data).entries
 
         #expect(entries.count == 2)
         #expect(entries[0].title == "Feed A")
@@ -200,7 +251,7 @@ struct OPMLServiceTests {
     @Test("generates valid OPML from empty feed list")
     func generatesEmptyOPML() throws {
         let data = try service.generateOPML(from: [] as [SubscribedFeed])
-        let entries = try service.parseOPML(data)
+        let entries = try service.parseOPML(data).entries
 
         #expect(entries.isEmpty)
     }
@@ -222,7 +273,7 @@ struct OPMLServiceTests {
         #expect(xml.contains("It&apos;s &lt;special&gt;"))
 
         // Verify it still parses correctly
-        let entries = try service.parseOPML(data)
+        let entries = try service.parseOPML(data).entries
         #expect(entries.count == 1)
         #expect(entries[0].title == "Feed <A> & \"B\"")
     }
@@ -278,7 +329,7 @@ struct OPMLServiceTests {
               </body>
             </opml>
             """
-        let entries = try service.parseOPML(Data(opml.utf8))
+        let entries = try service.parseOPML(Data(opml.utf8)).entries
 
         #expect(entries.count == 4)
         #expect(entries[0].title == "Ars")
@@ -307,7 +358,7 @@ struct OPMLServiceTests {
               </body>
             </opml>
             """
-        let entries = try service.parseOPML(Data(opml.utf8))
+        let entries = try service.parseOPML(Data(opml.utf8)).entries
 
         // Feed appears once per category — two entries with different group names.
         #expect(entries.count == 2)
@@ -329,7 +380,7 @@ struct OPMLServiceTests {
               </body>
             </opml>
             """
-        let entries = try service.parseOPML(Data(opml.utf8))
+        let entries = try service.parseOPML(Data(opml.utf8)).entries
 
         #expect(entries.count == 1)
         #expect(entries[0].groupName == "My Category")
@@ -348,7 +399,7 @@ struct OPMLServiceTests {
               </body>
             </opml>
             """
-        let entries = try service.parseOPML(Data(opml.utf8))
+        let entries = try service.parseOPML(Data(opml.utf8)).entries
 
         #expect(entries.count == 1)
         // Category outline with no text/title attributes is skipped as a group.
@@ -372,7 +423,7 @@ struct OPMLServiceTests {
               </body>
             </opml>
             """
-        let entries = try service.parseOPML(Data(opml.utf8))
+        let entries = try service.parseOPML(Data(opml.utf8)).entries
 
         #expect(entries.count == 3)
         #expect(entries[0].groupName == "Category A")
@@ -410,7 +461,7 @@ struct OPMLServiceTests {
 
         // Ungrouped feed should be at top level (not nested).
         // Verify by round-tripping.
-        let entries = try service.parseOPML(data)
+        let entries = try service.parseOPML(data).entries
         #expect(entries.count == 3)
 
         let techEntry = entries.first { $0.feedURL == URL(string: "https://tech.com/feed") }
@@ -432,7 +483,7 @@ struct OPMLServiceTests {
         ]
 
         let data = try service.generateOPML(from: groupedFeeds)
-        let entries = try service.parseOPML(data)
+        let entries = try service.parseOPML(data).entries
 
         // Feed should appear under both categories.
         #expect(entries.count == 2)
@@ -458,7 +509,7 @@ struct OPMLServiceTests {
         ]
 
         let data = try service.generateOPML(from: groupedFeeds)
-        let entries = try service.parseOPML(data)
+        let entries = try service.parseOPML(data).entries
 
         #expect(entries.count == 3)
         #expect(entries[0].title == "Feed A")
@@ -507,7 +558,7 @@ struct OPMLServiceTests {
         #expect(xml.contains("Tech &amp; Science"))
 
         // Verify round-trip preserves the name.
-        let entries = try service.parseOPML(data)
+        let entries = try service.parseOPML(data).entries
         #expect(entries[0].groupName == "Tech & Science")
     }
 

--- a/RSSAppTests/ViewModels/FeedListViewModelTests.swift
+++ b/RSSAppTests/ViewModels/FeedListViewModelTests.swift
@@ -1447,6 +1447,43 @@ struct FeedListViewModelTests {
         #expect(viewModel.errorMessage == nil)
     }
 
+    // MARK: - OPML Parse Skip Count
+
+    @Test("importOPML propagates parseSkippedCount from parse result into OPMLImportResult")
+    @MainActor
+    func importOPMLPropagatesParseSkippedCount() {
+        let mockPersistence = MockFeedPersistenceService()
+        let mockOPML = MockOPMLService()
+        // Simulate the parser returning 2 valid entries and reporting 3 skipped
+        mockOPML.entriesToReturn = [
+            TestFixtures.makeOPMLFeedEntry(title: "Feed A", feedURL: URL(string: "https://a.com/feed")!),
+            TestFixtures.makeOPMLFeedEntry(title: "Feed B", feedURL: URL(string: "https://b.com/feed")!),
+        ]
+        mockOPML.parseSkippedCountToReturn = 3
+
+        let viewModel = Self.makeViewModel(persistence: mockPersistence, opmlService: mockOPML)
+        viewModel.importOPML(from: Data())
+
+        #expect(viewModel.opmlImportResult?.addedCount == 2)
+        #expect(viewModel.opmlImportResult?.parseSkippedCount == 3)
+    }
+
+    @Test("importOPML result has zero parseSkippedCount when no entries were skipped")
+    @MainActor
+    func importOPMLParseSkippedCountIsZeroWhenNoneSkipped() {
+        let mockPersistence = MockFeedPersistenceService()
+        let mockOPML = MockOPMLService()
+        mockOPML.entriesToReturn = [
+            TestFixtures.makeOPMLFeedEntry(title: "Feed A", feedURL: URL(string: "https://a.com/feed")!),
+        ]
+        mockOPML.parseSkippedCountToReturn = 0
+
+        let viewModel = Self.makeViewModel(persistence: mockPersistence, opmlService: mockOPML)
+        viewModel.importOPML(from: Data())
+
+        #expect(viewModel.opmlImportResult?.parseSkippedCount == 0)
+    }
+
     // MARK: - OPML Import sortOrder
 
     @Test("importOPML assigns incrementing sortOrder starting after existing feeds")


### PR DESCRIPTION
## Summary
- Adds a `parseSkippedCount` field to `OPMLParseResult` and `OPMLImportResult` so that feed outlines silently dropped during OPML parsing (due to invalid `xmlUrl` values) are now counted and surfaced to the user
- The post-import alert in Settings now shows a bullet like "3 entries in the file had invalid feed URLs and were skipped" when applicable, giving users actionable feedback when an import is lossy

## Changes
- `OPMLService.swift`: Add `OPMLParseResult` struct (`entries` + `parseSkippedCount`); update `OPMLServing.parseOPML` signature to return it; increment `parseSkippedCount` in `OPMLParserDelegate` whenever a feed outline's `xmlUrl` cannot be parsed as a valid `URL`
- `OPMLImportResult.swift`: Add `parseSkippedCount: Int` (default `0`); include it in `totalInFile`
- `FeedListViewModel.swift`: Propagate `parseSkippedCount` from parse result into `OPMLImportResult`
- `SettingsView.swift`: Update `importResultMessage` to append a parse-skipped bullet with singular/plural wording; update the "all duplicates" fast-path to also require `parseSkippedCount == 0`
- `MockOPMLService.swift`: Expose `parseSkippedCountToReturn` and return `OPMLParseResult`
- `OPMLServiceTests.swift`: Update all `parseOPML` call sites to use `.entries`; add three new tests for `parseSkippedCount` behavior
- `FeedListViewModelTests.swift`: Add two tests verifying end-to-end propagation of `parseSkippedCount`

## Test plan
- [x] `parseSkippedCountIsZeroForValidEntries` — zero skip count for a clean OPML file
- [x] `parseSkippedCountMixedValidAndInvalid` — count reflects only invalid entries
- [x] `parseSkippedCountAllInvalid` — count equals total when every entry is invalid
- [x] `importOPMLPropagatesParseSkippedCount` — ViewModel propagates count into result
- [x] `importOPMLParseSkippedCountIsZeroWhenNoneSkipped` — zero count preserved end-to-end
- [x] All existing OPMLServiceTests and FeedListViewModelTests pass

Closes #356