### PR TITLE
fix: Remove Edit Group and Delete Group from ArticleListScreen toolbar menu (#379)

### DIFF
--- a/RSSApp/ViewModels/ArticleListSource.swift
+++ b/RSSApp/ViewModels/ArticleListSource.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Observation
-import os
 
 /// Display content for an article list's empty state. Each `ArticleListSource`
 /// supplies its own so the shared view can render per-screen copy (e.g.
@@ -146,54 +145,8 @@ protocol ArticleListSource: AnyObject, Observable {
     // MARK: - Error dismissal
 
     func clearError()
-
-    // MARK: - Group editing (optional capability)
-
-    /// Whether this source supports in-screen group editing (Edit Group /
-    /// Delete Group). Only `GroupArticleSource` returns `true`.
-    var supportsGroupEdit: Bool { get }
-
-    /// The underlying `PersistentFeedGroup` for sources that support group
-    /// editing. `nil` for all non-group sources.
-    var editableGroup: PersistentFeedGroup? { get }
-
-    /// Deletes the group backing this source. Called after the user confirms
-    /// the delete alert. After this call, `wasGroupDeleted` must become `true`
-    /// so `ArticleListScreen` can dismiss and pop the navigation stack.
-    func deleteGroup()
-
-    /// Becomes `true` after a successful `deleteGroup()` call. Observed by
-    /// `ArticleListScreen` to trigger auto-dismiss (pop back to Home).
-    var wasGroupDeleted: Bool { get }
-
-    /// Error message set when `deleteGroup()` fails. Distinct from `errorMessage`
-    /// so the delete-error alert fires regardless of whether the article list is
-    /// empty — the `errorAlertBinding` gates on `!source.articles.isEmpty` to
-    /// avoid conflicts with the empty-state error row, but delete errors must
-    /// always surface to the user.
-    var deleteErrorMessage: String? { get }
 }
-
-/// A shared logger used by the `ArticleListSource` protocol extension defaults
-/// where no concrete type's logger is available.
-private let articleListSourceLogger = Logger(category: "ArticleListSource")
 
 extension ArticleListSource {
     func onDisappear() {}
-
-    // MARK: - Group editing defaults
-
-    var supportsGroupEdit: Bool { false }
-    var editableGroup: PersistentFeedGroup? { nil }
-
-    func deleteGroup() {
-        // RATIONALE: Defensive fault log + assertionFailure per project guidelines.
-        // This default fires only if a non-group source accidentally receives a
-        // deleteGroup() call — impossible in production UI but catchable in tests.
-        articleListSourceLogger.fault("deleteGroup() called on a source that does not support group editing")
-        assertionFailure("deleteGroup() called on a source that does not support group editing")
-    }
-
-    var wasGroupDeleted: Bool { false }
-    var deleteErrorMessage: String? { nil }
 }

--- a/RSSApp/ViewModels/GroupArticleSource.swift
+++ b/RSSApp/ViewModels/GroupArticleSource.swift
@@ -36,26 +36,6 @@ final class GroupArticleSource: ArticleListSource {
     var supportsSort: Bool { true }
     var supportsUnreadFilter: Bool { false }
 
-    // MARK: - Group editing capability
-
-    var supportsGroupEdit: Bool { true }
-    var editableGroup: PersistentFeedGroup? { group }
-    private(set) var wasGroupDeleted: Bool = false
-    private(set) var deleteErrorMessage: String?
-
-    func deleteGroup() {
-        let name = group.name
-        do {
-            try persistence.deleteGroup(group)
-            homeViewModel.loadGroups()
-            wasGroupDeleted = true
-            Self.logger.notice("Deleted group '\(name, privacy: .public)' from GroupArticleSource")
-        } catch {
-            deleteErrorMessage = "Unable to delete group."
-            Self.logger.error("Failed to delete group '\(name, privacy: .public)': \(error, privacy: .public)")
-        }
-    }
-
     var sortAscending: Bool {
         get { homeViewModel.sortAscending }
         set {

--- a/RSSApp/Views/ArticleListScreen.swift
+++ b/RSSApp/Views/ArticleListScreen.swift
@@ -35,14 +35,10 @@ struct ArticleListScreen<Source: ArticleListSource>: View {
         self.thumbnailService = thumbnailService
     }
 
-    @Environment(\.dismiss) private var dismiss
     @Environment(\.scenePhase) private var scenePhase
 
     @State private var selectedArticleIndex: Int?
     @State private var showMarkAllReadConfirmation = false
-    @State private var showEditGroupSheet = false
-    @State private var showDeleteGroupConfirmation = false
-    @State private var deleteErrorMessage: String?
     @State private var hasAppeared = false
     // RATIONALE: Snapshot preservation across reader push/pop. See
     // ARCHITECTURE.md → "Snapshot preservation across reader push/pop (two gates)".
@@ -98,38 +94,6 @@ struct ArticleListScreen<Source: ArticleListSource>: View {
             Button("OK") { source.clearError() }
         } message: {
             Text(source.errorMessage ?? "")
-        }
-        .alert("Error", isPresented: deleteErrorAlertBinding) {
-            Button("OK") { deleteErrorMessage = nil }
-        } message: {
-            Text(deleteErrorMessage ?? "")
-        }
-        .alert(
-            "Delete Group?",
-            isPresented: $showDeleteGroupConfirmation,
-            presenting: source.editableGroup
-        ) { group in
-            Button("Delete", role: .destructive) {
-                source.deleteGroup()
-            }
-            Button("Cancel", role: .cancel) { }
-        } message: { group in
-            Text("\"\(group.name)\" will be deleted. Its feeds will not be removed.")
-        }
-        .sheet(isPresented: $showEditGroupSheet, onDismiss: { source.reload() }) {
-            if let group = source.editableGroup {
-                EditGroupView(group: group, persistence: persistence)
-            }
-        }
-        .onChange(of: source.wasGroupDeleted) { _, deleted in
-            if deleted {
-                dismiss()
-            }
-        }
-        .onChange(of: source.deleteErrorMessage) { _, message in
-            if let message {
-                deleteErrorMessage = message
-            }
         }
         .task {
             // RATIONALE: First half of the two-gate snapshot-preservation
@@ -325,22 +289,6 @@ struct ArticleListScreen<Source: ArticleListSource>: View {
                 } label: {
                     Label("Mark All as Read", systemImage: "checkmark.circle")
                 }
-
-                if source.supportsGroupEdit {
-                    Divider()
-
-                    Button {
-                        showEditGroupSheet = true
-                    } label: {
-                        Label("Edit Group", systemImage: "pencil")
-                    }
-
-                    Button(role: .destructive) {
-                        showDeleteGroupConfirmation = true
-                    } label: {
-                        Label("Delete Group", systemImage: "trash")
-                    }
-                }
             } label: {
                 Image(systemName: "ellipsis.circle")
             }
@@ -356,16 +304,6 @@ struct ArticleListScreen<Source: ArticleListSource>: View {
         Binding(
             get: { source.errorMessage != nil && !source.articles.isEmpty },
             set: { if !$0 { source.clearError() } }
-        )
-    }
-
-    /// Always shown when a delete-group failure occurs, regardless of whether
-    /// the article list is empty — delete errors must surface even on empty
-    /// groups, which are the most natural targets for deletion.
-    private var deleteErrorAlertBinding: Binding<Bool> {
-        Binding(
-            get: { deleteErrorMessage != nil },
-            set: { if !$0 { deleteErrorMessage = nil } }
         )
     }
 }

--- a/RSSAppTests/ViewModels/GroupArticleSourceTests.swift
+++ b/RSSAppTests/ViewModels/GroupArticleSourceTests.swift
@@ -232,30 +232,6 @@ struct GroupArticleSourceTests {
         #expect(source.errorMessage == nil)
     }
 
-    // MARK: - Group deletion
-
-    @Test("deleteGroup() success sets wasGroupDeleted and removes group from persistence")
-    @MainActor
-    func deleteGroupSuccess() {
-        let (source, mock, group) = Self.makeFixture()
-        source.deleteGroup()
-
-        #expect(source.wasGroupDeleted == true)
-        #expect(source.deleteErrorMessage == nil)
-        #expect(!mock.groups.contains { $0.id == group.id })
-    }
-
-    @Test("deleteGroup() failure sets deleteErrorMessage and leaves wasGroupDeleted false")
-    @MainActor
-    func deleteGroupFailure() {
-        let (source, mock, _) = Self.makeFixture()
-        mock.groupError = NSError(domain: "test", code: 1)
-        source.deleteGroup()
-
-        #expect(source.wasGroupDeleted == false)
-        #expect(source.deleteErrorMessage != nil)
-    }
-
     // MARK: - Sort
 
     @Test("sortAscending toggle reloads articles in new order")


### PR DESCRIPTION
## Summary
- Removes "Edit Group" and "Delete Group" menu items from the `...` toolbar in `ArticleListScreen`, reducing clutter
- Group editing remains available via swipe actions on group rows in `HomeView`

## Changes
- Removed `supportsGroupEdit`, `editableGroup`, `deleteGroup()`, `wasGroupDeleted`, and `deleteErrorMessage` from the `ArticleListSource` protocol and its extension defaults
- Removed the group editing capability section from `GroupArticleSource`
- Removed all group editing infrastructure from `ArticleListScreen`: state vars, alerts, sheet, `.onChange` observers, toolbar items, and `deleteErrorAlertBinding`
- Removed the `deleteGroupSuccess` and `deleteGroupFailure` tests from `GroupArticleSourceTests`

## Test plan
- [x] Built successfully for iOS 26
- [x] All 1157 existing tests pass

Closes #379