### PR TITLE
feat: Add middle dot separator and simplify article row footer layout (#380)

### DIFF
--- a/RSSApp/Views/ArticleRowView.swift
+++ b/RSSApp/Views/ArticleRowView.swift
@@ -52,39 +52,39 @@ struct ArticleRowView: View {
         }
     }
 
-    /// Bottom metadata block — feed source, publish date, saved indicator, and
-    /// (optionally) the "Updated" suffix and call-to-action badge, laid out as:
+    /// Bottom metadata block — feed source, date, saved indicator, and
+    /// (optionally) the "Updated" call-to-action badge, laid out as a single
+    /// left-aligned row:
     ///
-    ///     [icon] Feed title        Apr 8              [bookmark]
-    ///     Updated 9 hours ago
+    ///     [icon] Feed title · Apr 8                          [bookmark]
+    ///     [icon] Feed title · Updated 3 hours ago            [bookmark]
+    ///     [icon] Feed title · Apr 8  [Updated]               [bookmark]
     ///
-    /// The left column is a `VStack` holding the feed label and (when present)
-    /// the updated line — stacking the relative freshness directly under the
-    /// feed source so the right side of the row stays compact and the feed
-    /// identity + freshness read as a single left-anchored block. The outer
-    /// `HStack(alignment: .firstTextBaseline)` baseline-aligns the feed name
-    /// with the publish date so they sit on the same line instead of the feed
-    /// name vertically centering against the two-row left column.
-    ///
-    /// This was previously a SwiftUI `Grid` for explicit column alignment, but
-    /// `Grid`'s column-sizing algorithm shrinks non-flex columns to the width
-    /// of their longest unbreakable token (longest word) rather than their
-    /// natural single-line width. That forced mid-word wraps even with plenty
-    /// of horizontal space — e.g. "AWS Architecture Blog" broke at "AWS
-    /// Architecture / Blog", and "Updated 9 hours ago" broke at "Updated 9 /
-    /// hours ago". The HStack version lets each child size to its natural
-    /// width and the trailing `Spacer` absorbs the slack, so nothing wraps
-    /// until the row actually runs out of room.
+    /// A middle dot (`·`) separates the feed name from the date or updated
+    /// text. When `shouldShowUpdatedSuffix` is true the dot precedes the
+    /// relative freshness string; otherwise it precedes the absolute publish
+    /// date. The orange "Updated" capsule badge is appended when `wasUpdated`
+    /// is true.
     @ViewBuilder
     private var metadataFooter: some View {
         HStack(alignment: .firstTextBaseline, spacing: 6) {
-            VStack(alignment: .leading, spacing: 2) {
-                feedLabel
-                if article.shouldShowUpdatedSuffix || article.wasUpdated {
-                    updatedLine
-                }
+            feedLabel
+            Text("·")
+                .foregroundStyle(.tertiary)
+            if article.shouldShowUpdatedSuffix, let updated = article.updatedDate {
+                Text("Updated \(updated, format: .relative(presentation: .named))")
+            } else {
+                Text(publishDateText)
             }
-            Text(publishDateText)
+            if article.wasUpdated {
+                Text("Updated")
+                    .font(.caption2)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.orange)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Color.orange.opacity(0.15), in: Capsule())
+            }
             Spacer(minLength: 0)
             savedIndicator
         }
@@ -134,39 +134,7 @@ struct ArticleRowView: View {
             .accessibilityHidden(!article.isSaved)
     }
 
-    /// Row 2 content — the "Updated [relative date]" informational suffix and
-    /// (optionally) the orange call-to-action capsule badge. Rendered only
-    /// when `shouldShowUpdatedSuffix || wasUpdated`.
-    ///
-    /// - `shouldShowUpdatedSuffix` is kept relative ("Updated 3 days ago") so
-    ///   freshness reads at a glance and is independent of the user's read
-    ///   state, so it remains visible even after reading the latest version.
-    /// - `wasUpdated` is the call-to-action: an orange capsule marking the
-    ///   article as having new content the user hasn't read yet. Clears on
-    ///   every read transition (`markArticleRead`, `markAllArticlesRead`).
-    ///   When the suffix is suppressed (e.g. a feed reports `updated <=
-    ///   published` per issue #299) but `wasUpdated` is still true, the badge
-    ///   stands alone so the call to action is never lost.
-    @ViewBuilder
-    private var updatedLine: some View {
-        HStack(spacing: 6) {
-            if article.shouldShowUpdatedSuffix, let updated = article.updatedDate {
-                Text("Updated \(updated, format: .relative(presentation: .named))")
-            }
-
-            if article.wasUpdated {
-                Text("Updated")
-                    .font(.caption2)
-                    .fontWeight(.semibold)
-                    .foregroundStyle(.orange)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(Color.orange.opacity(0.15), in: Capsule())
-            }
-        }
-    }
-
-    /// Absolute short date for the publish line. Omits the year when
+    /// Absolute short date shown after the middle dot. Omits the year when
     /// `displayedPublishedDate` is in the current calendar year, includes it
     /// otherwise — keeps the common case compact ("Apr 7") while staying
     /// unambiguous across year boundaries ("Dec 28, 2024" vs this year's

--- a/RSSApp/Views/ArticleRowView.swift
+++ b/RSSApp/Views/ArticleRowView.swift
@@ -71,6 +71,7 @@ struct ArticleRowView: View {
             feedLabel
             Text("·")
                 .foregroundStyle(.tertiary)
+                .accessibilityHidden(true)
             if article.shouldShowUpdatedSuffix, let updated = article.updatedDate {
                 Text("Updated \(updated, format: .relative(presentation: .named))")
             } else {


### PR DESCRIPTION
## Summary
- Adds a middle dot (`·`, U+00B7) separator between the feed name and date/updated text in `ArticleRowView`'s metadata footer, styled with `.foregroundStyle(.tertiary)` for a subtle visual break
- Flattens the footer from a nested `VStack`+`HStack` layout into a single left-aligned `HStack`

The new layout reads as:
```
[icon] Feed title · Apr 8                          [bookmark]
[icon] Feed title · Updated 3 hours ago            [bookmark]
[icon] Feed title · Apr 8  [Updated]               [bookmark]
```

## Changes
- `RSSApp/Views/ArticleRowView.swift`: Remove inner `VStack` from `metadataFooter`; all elements flow in a single `HStack`. Add `Text("·")` with `.foregroundStyle(.tertiary)` as separator. Inline `updatedLine` content into `metadataFooter` and remove the `updatedLine` computed property. Update doc comment to reflect the new single-row layout.

## Test plan
- [x] Built successfully for iOS 26 simulator with no errors or warnings

Closes #380