### PR TITLE
feat: Reduce article list row margins and enlarge thumbnails (#383)

### DIFF
--- a/RSSApp/Views/ArticleListScreen.swift
+++ b/RSSApp/Views/ArticleListScreen.swift
@@ -253,7 +253,7 @@ struct ArticleListScreen<Source: ArticleListSource>: View {
             }
             .buttonStyle(.plain)
             .disabled(article.link == nil)
-            .listRowInsets(EdgeInsets(top: 10, leading: 20, bottom: 10, trailing: 20))
+            .listRowInsets(EdgeInsets(top: 10, leading: 8, bottom: 10, trailing: 8))
             .swipeActions(edge: .leading) {
                 Button {
                     source.toggleReadStatus(article)

--- a/RSSApp/Views/ArticleThumbnailView.swift
+++ b/RSSApp/Views/ArticleThumbnailView.swift
@@ -14,7 +14,7 @@ struct ArticleThumbnailView: View {
     @State private var thumbnailImage: UIImage?
 
     private static let logger = Logger(category: "ArticleThumbnailView")
-    private static let thumbnailSize: CGFloat = 60
+    private static let thumbnailSize: CGFloat = 72
     private static let cornerRadius: CGFloat = 8
 
     var body: some View {


### PR DESCRIPTION
## Summary
- Reduces `listRowInsets` leading/trailing from 20pt to 8pt, giving article content more horizontal room to breathe
- Increases thumbnail size from 60×60 to 72×72, making article images more prominent
- Both changes apply uniformly across all article list views (All Articles, Unread Articles, Saved Articles, per-feed lists, and per-group lists) since they all flow through the shared `ArticleListScreen` and `ArticleThumbnailView`

Closes #383

## Test plan
- [x] Built successfully for iOS 26
- [x] All existing tests pass