### PR TITLE
fix: Add lock synchronization to MockArticleThumbnailService for concurrent access

### DIFF
--- a/RSSAppTests/Mocks/MockArticleThumbnailService.swift
+++ b/RSSAppTests/Mocks/MockArticleThumbnailService.swift
@@ -1,9 +1,12 @@
 import Foundation
 @testable import RSSApp
 
-// RATIONALE: @unchecked Sendable is safe because the mock is only used in sequential
-// test methods within a single test actor — no concurrent mutation occurs.
+// RATIONALE: @unchecked Sendable is safe because all mutable state is protected by `lock`.
+// ThumbnailPrefetchService calls resolveAndCacheThumbnail from concurrent task group children,
+// so the lock is required to prevent data races on counters and arrays.
 final class MockArticleThumbnailService: ArticleThumbnailCaching, @unchecked Sendable {
+
+    private let lock = NSLock()
 
     var cacheResult: ThumbnailCacheResult = .cached
     var resolveResult: ThumbnailCacheResult = .cached
@@ -11,15 +14,24 @@ final class MockArticleThumbnailService: ArticleThumbnailCaching, @unchecked Sen
     /// instead of returning. Used to exercise cancellation propagation paths.
     var throwCancellation = false
     var cachedFileURL: URL?
-    var cacheCallCount = 0
-    var resolveCallCount = 0
-    var deleteCallCount = 0
-    var cachedArticleIDs: [String] = []
-    var deletedArticleIDs: [String] = []
+
+    private var _cacheCallCount = 0
+    private var _resolveCallCount = 0
+    private var _deleteCallCount = 0
+    private var _cachedArticleIDs: [String] = []
+    private var _deletedArticleIDs: [String] = []
+
+    var cacheCallCount: Int { lock.withLock { _cacheCallCount } }
+    var resolveCallCount: Int { lock.withLock { _resolveCallCount } }
+    var deleteCallCount: Int { lock.withLock { _deleteCallCount } }
+    var cachedArticleIDs: [String] { lock.withLock { _cachedArticleIDs } }
+    var deletedArticleIDs: [String] { lock.withLock { _deletedArticleIDs } }
 
     func cacheThumbnail(from remoteURL: URL, articleID: String) async throws(CancellationError) -> ThumbnailCacheResult {
-        cacheCallCount += 1
-        cachedArticleIDs.append(articleID)
+        lock.withLock {
+            _cacheCallCount += 1
+            _cachedArticleIDs.append(articleID)
+        }
         if throwCancellation {
             throw CancellationError()
         }
@@ -27,8 +39,10 @@ final class MockArticleThumbnailService: ArticleThumbnailCaching, @unchecked Sen
     }
 
     func resolveAndCacheThumbnail(thumbnailURL: URL?, articleLink: URL?, articleID: String) async throws(CancellationError) -> ThumbnailCacheResult {
-        resolveCallCount += 1
-        cachedArticleIDs.append(articleID)
+        lock.withLock {
+            _resolveCallCount += 1
+            _cachedArticleIDs.append(articleID)
+        }
         if throwCancellation {
             throw CancellationError()
         }
@@ -40,7 +54,9 @@ final class MockArticleThumbnailService: ArticleThumbnailCaching, @unchecked Sen
     }
 
     func deleteCachedThumbnail(for articleID: String) {
-        deleteCallCount += 1
-        deletedArticleIDs.append(articleID)
+        lock.withLock {
+            _deleteCallCount += 1
+            _deletedArticleIDs.append(articleID)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Fix data race crash (`EXC_BAD_ACCESS`/`SIGSEGV`) in `MockArticleThumbnailService` when `ThumbnailPrefetchService` exercises concurrent task group downloads
- The mock's mutable counters and arrays were unsynchronized despite being accessed from multiple concurrent tasks via `withTaskGroup`
- Crash manifested as pointer authentication failure during `Array.append` on Thread 9 (`com.apple.root.user-initiated-qos.cooperative`)

## Changes
- Add `NSLock` to `MockArticleThumbnailService`, protecting all mutable state behind `lock.withLock`
- Make backing storage private with thread-safe computed property accessors
- Update `RATIONALE:` comment to accurately describe the concurrency situation (previous comment incorrectly claimed "no concurrent mutation occurs")
- Matches the synchronization pattern already used by `SequenceThumbnailMock` in `ThumbnailPrefetchServiceTests`

## Test plan
- [x] All `ThumbnailPrefetchServiceTests` pass (concurrent task group path)
- [x] All `ArticleThumbnailServiceTests` pass
- [x] Full test suite passes (one unrelated pre-existing flaky test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)