### PR TITLE
refactor: Replace inline Binding nil-checks with Binding.isPresented() extension

### DIFF
--- a/RSSApp/Extensions/Binding+IsPresented.swift
+++ b/RSSApp/Extensions/Binding+IsPresented.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+extension Binding {
+    /// Returns a `Binding<Bool>` that is `true` when the wrapped optional is
+    /// non-nil, and sets it to `nil` when assigned `false`. Assigning `true`
+    /// has no effect; set the underlying optional to a non-nil value to trigger
+    /// presentation.
+    ///
+    /// Use this to drive `isPresented:` parameters on alerts, sheets, and
+    /// other SwiftUI modifiers from an optional state value:
+    ///
+    /// ```swift
+    /// .alert("Error", isPresented: $errorMessage.isPresented()) { … }
+    /// ```
+    func isPresented<Wrapped>() -> Binding<Bool> where Value == Wrapped? {
+        Binding<Bool>(
+            get: { wrappedValue != nil },
+            set: { if !$0 { wrappedValue = nil } }
+        )
+    }
+}

--- a/RSSApp/ViewModels/AddFeedViewModel.swift
+++ b/RSSApp/ViewModels/AddFeedViewModel.swift
@@ -28,7 +28,12 @@ final class AddFeedViewModel {
             // the property moves from a non-nil value to nil. Re-assigning
             // nil (e.g. a second binding-setter call during alert dismissal)
             // is a no-op so the observation tracker stays clean.
-            guard oldValue != nil, atomFallbackNotice == nil else { return }
+            guard oldValue != nil, atomFallbackNotice == nil else {
+                if oldValue == nil, atomFallbackNotice == nil {
+                    Self.logger.debug("atomFallbackNotice double-fire ignored (was already nil)")
+                }
+                return
+            }
             didAddFeed = true
         }
     }

--- a/RSSApp/ViewModels/EditFeedViewModel.swift
+++ b/RSSApp/ViewModels/EditFeedViewModel.swift
@@ -27,7 +27,12 @@ final class EditFeedViewModel {
             // property moves from a non-nil value to nil. Re-assigning nil
             // (e.g. a second binding-setter call during alert dismissal) is
             // a no-op so the observation tracker stays clean.
-            guard oldValue != nil, atomFallbackNotice == nil else { return }
+            guard oldValue != nil, atomFallbackNotice == nil else {
+                if oldValue == nil, atomFallbackNotice == nil {
+                    Self.logger.debug("atomFallbackNotice double-fire ignored (was already nil)")
+                }
+                return
+            }
             didSave = true
         }
     }

--- a/RSSApp/Views/APIKeySettingsView.swift
+++ b/RSSApp/Views/APIKeySettingsView.swift
@@ -75,17 +75,17 @@ struct APIKeySettingsView: View {
         } message: {
             Text("Your Anthropic API key has been saved to the Keychain.")
         }
-        .alert("Save Failed", isPresented: Binding(presentingIfNonNil: $saveError)) {
+        .alert("Save Failed", isPresented: $saveError.isPresented()) {
             Button("OK", role: .cancel) {}
         } message: {
             Text(saveError ?? "")
         }
-        .alert("Remove Failed", isPresented: Binding(presentingIfNonNil: $deleteError)) {
+        .alert("Remove Failed", isPresented: $deleteError.isPresented()) {
             Button("OK", role: .cancel) {}
         } message: {
             Text(deleteError ?? "")
         }
-        .alert("Load Failed", isPresented: Binding(presentingIfNonNil: $loadError)) {
+        .alert("Load Failed", isPresented: $loadError.isPresented()) {
             Button("OK", role: .cancel) {}
         } message: {
             Text(loadError ?? "")

--- a/RSSApp/Views/ArticleDiscussionView.swift
+++ b/RSSApp/Views/ArticleDiscussionView.swift
@@ -32,10 +32,7 @@ struct ArticleDiscussionView: View {
                     Button("Done") { dismiss() }
                 }
             }
-            .alert("Send Failed", isPresented: Binding(
-                get: { viewModel.errorMessage != nil },
-                set: { if !$0 { viewModel.errorMessage = nil } }
-            )) {
+            .alert("Send Failed", isPresented: $viewModel.errorMessage.isPresented()) {
                 Button("OK", role: .cancel) {}
             } message: {
                 Text(viewModel.errorMessage ?? "")

--- a/RSSApp/Views/ArticleReaderView.swift
+++ b/RSSApp/Views/ArticleReaderView.swift
@@ -176,18 +176,12 @@ struct ArticleReaderView: View {
                         persistence: persistence
                     )
                 }
-                .alert("Error", isPresented: errorAlertBinding) {
+                .alert("Error", isPresented: $errorMessage.isPresented()) {
                     Button("OK") { errorMessage = nil }
                 } message: {
                     Text(errorMessage ?? "")
                 }
         }
-    }
-
-    // MARK: - Helpers
-
-    private var errorAlertBinding: Binding<Bool> {
-        Binding(presentingIfNonNil: $errorMessage)
     }
 
     // MARK: - Navigation

--- a/RSSApp/Views/AtomFeedAlertsModifier.swift
+++ b/RSSApp/Views/AtomFeedAlertsModifier.swift
@@ -30,7 +30,7 @@ struct AtomFeedAlerts: ViewModifier {
         content
             .alert(
                 "Atom feed available",
-                isPresented: Binding(presentingIfNonNil: $atomAlternatePrompt),
+                isPresented: $atomAlternatePrompt.isPresented(),
                 presenting: atomAlternatePrompt
             ) { prompt in
                 // RATIONALE: We pass `prompt` directly into switchToAtom/keepRSS
@@ -52,9 +52,10 @@ struct AtomFeedAlerts: ViewModifier {
             }
             .alert(
                 "Atom feed unavailable",
-                // Acknowledging the notice clears it; the view model's
-                // didSet on atomFallbackNotice then signals sheet dismissal.
-                isPresented: Binding(presentingIfNonNil: $atomFallbackNotice),
+                // RATIONALE: isPresented() sets the optional to nil on dismissal,
+                // which the view model's didSet on atomFallbackNotice observes to
+                // set didSave/didAddFeed = true, signaling sheet dismissal via .onChange.
+                isPresented: $atomFallbackNotice.isPresented(),
                 presenting: atomFallbackNotice
             ) { _ in
                 Button("OK", role: .cancel) { }

--- a/RSSApp/Views/BackgroundRefreshSettingsView.swift
+++ b/RSSApp/Views/BackgroundRefreshSettingsView.swift
@@ -111,10 +111,7 @@ struct BackgroundRefreshSettingsView: View {
         .navigationTitle("Background Refresh")
         .alert(
             "Background Refresh Unavailable",
-            isPresented: Binding(
-                get: { scheduleError != nil },
-                set: { if !$0 { scheduleError = nil } }
-            ),
+            isPresented: $scheduleError.isPresented(),
             presenting: scheduleError
         ) { _ in
             Button("OK") { scheduleError = nil }

--- a/RSSApp/Views/FeedListView.swift
+++ b/RSSApp/Views/FeedListView.swift
@@ -107,7 +107,7 @@ struct FeedListView: View {
             }) { feed in
                 EditFeedView(feed: feed, persistence: persistence)
             }
-            .alert("Error", isPresented: errorAlertBinding) {
+            .alert("Error", isPresented: $viewModel.errorMessage.isPresented()) {
                 Button("OK") { viewModel.errorMessage = nil }
             } message: {
                 Text(viewModel.errorMessage ?? "")
@@ -185,9 +185,4 @@ struct FeedListView: View {
         }
     }
 
-    // MARK: - Helpers
-
-    private var errorAlertBinding: Binding<Bool> {
-        Binding(presentingIfNonNil: $viewModel.errorMessage)
-    }
 }

--- a/RSSApp/Views/HomeView.swift
+++ b/RSSApp/Views/HomeView.swift
@@ -210,10 +210,7 @@ struct HomeView: View {
             }
             .alert(
                 "Delete Group?",
-                isPresented: Binding(
-                    get: { groupToDelete != nil },
-                    set: { if !$0 { groupToDelete = nil } }
-                ),
+                isPresented: $groupToDelete.isPresented(),
                 presenting: groupToDelete
             ) { group in
                 Button("Delete", role: .destructive) {

--- a/RSSAppTests/ViewModels/EditFeedViewModelTests.swift
+++ b/RSSAppTests/ViewModels/EditFeedViewModelTests.swift
@@ -338,9 +338,7 @@ struct EditFeedViewModelTests {
         #expect(viewModel.errorMessage == nil)
         #expect(feed.feedURL == rssURL)
         #expect(feed.title == "New RSS")
-        // The user's original (pre-edit) URL stays in the field while the
-        // notice is up — wait, actually they edited to rssURL, so rssURL
-        // is what they typed and should remain.
+        // The URL in the field is the one the user typed (rssURL), not the original feed URL.
         #expect(viewModel.urlInput == rssURL.absoluteString)
 
         // Simulate the user tapping OK on the notice (nils the binding,


### PR DESCRIPTION
## Summary
- Introduces `Binding.isPresented()`, a method extension on `Binding<T?>` that returns a `Binding<Bool>` — `true` when the wrapped value is non-nil, clearing it to `nil` on dismissal
- Replaces all applicable inline `Binding(get: { x != nil }, set: { if !$0 { x = nil } })` patterns with `$x.isPresented()`, making alert bindings more readable and idiomatic at call sites
- Removes now-redundant `errorAlertBinding` computed properties from `ArticleReaderView` and `FeedListView`

## Changes
- New: `RSSApp/Extensions/Binding+IsPresented.swift`
- Updated: `APIKeySettingsView`, `ArticleDiscussionView`, `AtomFeedAlertsModifier`, `BackgroundRefreshSettingsView`, `FeedListView`, `HomeView`, `ArticleReaderView`
- Left unchanged: `HomeView.errorAlertBinding` (calls `clearError()`) and `ArticleListScreen.errorAlertBinding` (compound `!= nil && !isEmpty` guard) — both have non-trivial logic the generic extension cannot express

## Test plan
- [x] Built successfully for iOS 26 Simulator
- [x] All existing tests pass

Closes #394