### PR TITLE
fix: Persist icon background style from fire-and-forget icon tasks

### DIFF
--- a/RSSApp/Services/FeedRefreshService.swift
+++ b/RSSApp/Services/FeedRefreshService.swift
@@ -682,15 +682,17 @@ final class FeedRefreshService {
             feedImageURL: feedImageURL,
             feedID: feed.id
         )
-        do {
-            try persistence.applyIconResolution(resolved, to: feed)
-            try persistence.save()
-        } catch {
-            // RATIONALE: No error surfaced to the caller. This runs inside a fire-and-forget
-            // Task spawned by performRefresh(), so mutating the caller's errorMessage would
-            // race with the post-refresh error state assignment. Icon persistence failure is
-            // also cosmetic and self-healing — the icon is re-resolved on the next refresh.
-            Self.logger.error("Failed to persist icon resolution for '\(feed.title, privacy: .public)': \(error, privacy: .public)")
+        if let resolved {
+            do {
+                try persistence.applyIconResolution(resolved, to: feed)
+                try persistence.save()
+            } catch {
+                // RATIONALE: No error surfaced to the caller. This runs inside a fire-and-forget
+                // Task spawned by performRefresh(), so mutating the caller's errorMessage would
+                // race with the post-refresh error state assignment. Icon persistence failure is
+                // also cosmetic and self-healing — the icon is re-resolved on the next refresh.
+                Self.logger.error("Failed to persist icon resolution for '\(feed.title, privacy: .public)': \(error, privacy: .public)")
+            }
         }
     }
 

--- a/RSSApp/Services/FeedRefreshService.swift
+++ b/RSSApp/Services/FeedRefreshService.swift
@@ -670,7 +670,7 @@ final class FeedRefreshService {
                     )
                     try persistence.save()
                 } catch {
-                    Self.logger.error("Failed to back-fill icon classification for '\(feed.title, privacy: .public)': \(error, privacy: .public)")
+                    Self.logger.error("Failed to persist back-filled icon classification for '\(feed.title, privacy: .public)': \(error, privacy: .public)")
                 }
             } else {
                 Self.logger.debug("Icon already cached and classified for '\(feed.title, privacy: .public)'")
@@ -690,7 +690,7 @@ final class FeedRefreshService {
             // Task spawned by performRefresh(), so mutating the caller's errorMessage would
             // race with the post-refresh error state assignment. Icon persistence failure is
             // also cosmetic and self-healing — the icon is re-resolved on the next refresh.
-            Self.logger.error("Failed to persist icon URL for '\(feed.title, privacy: .public)': \(error, privacy: .public)")
+            Self.logger.error("Failed to persist icon resolution for '\(feed.title, privacy: .public)': \(error, privacy: .public)")
         }
     }
 

--- a/RSSApp/Services/FeedRefreshService.swift
+++ b/RSSApp/Services/FeedRefreshService.swift
@@ -668,6 +668,7 @@ final class FeedRefreshService {
                         iconURL: feed.iconURL,
                         backgroundStyle: backgroundStyle
                     )
+                    try persistence.save()
                 } catch {
                     Self.logger.error("Failed to back-fill icon classification for '\(feed.title, privacy: .public)': \(error, privacy: .public)")
                 }
@@ -683,6 +684,7 @@ final class FeedRefreshService {
         )
         do {
             try persistence.applyIconResolution(resolved, to: feed)
+            try persistence.save()
         } catch {
             // RATIONALE: No error surfaced to the caller. This runs inside a fire-and-forget
             // Task spawned by performRefresh(), so mutating the caller's errorMessage would

--- a/RSSApp/Views/FeedIconView.swift
+++ b/RSSApp/Views/FeedIconView.swift
@@ -67,8 +67,10 @@ struct FeedIconView: View {
         resolvedBackgroundStyle ?? iconBackgroundStyle
     }
 
-    /// The tile color that best contrasts against the cached icon (issue #342).
-    /// `nil` → legacy black tile for feeds that predate the classifier.
+    /// The tile color that best contrasts against a loaded icon (issue #342).
+    /// Only applied when `iconImage` is non-nil; the placeholder always
+    /// uses a white tile (see `body`). `nil` → legacy black for feeds
+    /// that predate the classifier.
     private var backgroundColor: Color {
         switch effectiveBackgroundStyle {
         case .light: return .white
@@ -89,8 +91,8 @@ struct FeedIconView: View {
             } else {
                 // Placeholder globe while the icon resolves (or if the feed
                 // has no icon at all). Always on a white tile so the dark
-                // globe is legible and visually consistent regardless of
-                // whether icon resolution failed or succeeded-but-invalid.
+                // globe is legible and visually consistent. Sized at 60%
+                // of the icon frame so it scales with Dynamic Type.
                 Image(systemName: "globe")
                     .font(.system(size: iconSize * 0.6))
                     .foregroundStyle(.black.opacity(0.4))

--- a/RSSApp/Views/FeedIconView.swift
+++ b/RSSApp/Views/FeedIconView.swift
@@ -76,18 +76,10 @@ struct FeedIconView: View {
         }
     }
 
-    /// The globe placeholder color is paired with the background so it stays
-    /// legible regardless of which tile is rendered. The placeholder never
-    /// sits on an icon — it only shows while loading or when no icon exists
-    /// — so its color is chosen purely against the tile.
-    private var placeholderForegroundColor: Color {
-        effectiveBackgroundStyle == .light ? .black.opacity(0.4) : .white.opacity(0.6)
-    }
-
     var body: some View {
         ZStack {
             RoundedRectangle(cornerRadius: cornerRadius)
-                .fill(backgroundColor)
+                .fill(iconImage != nil ? backgroundColor : .white)
 
             if let iconImage {
                 Image(uiImage: iconImage)
@@ -96,11 +88,12 @@ struct FeedIconView: View {
                     .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
             } else {
                 // Placeholder globe while the icon resolves (or if the feed
-                // has no icon at all). Sized relative to the frame so it
-                // tracks Dynamic Type scaling at both style sizes.
+                // has no icon at all). Always on a white tile so the dark
+                // globe is legible and visually consistent regardless of
+                // whether icon resolution failed or succeeded-but-invalid.
                 Image(systemName: "globe")
                     .font(.system(size: iconSize * 0.6))
-                    .foregroundStyle(placeholderForegroundColor)
+                    .foregroundStyle(.black.opacity(0.4))
             }
         }
         .frame(width: iconSize, height: iconSize)

--- a/RSSApp/Views/FeedIconView.swift
+++ b/RSSApp/Views/FeedIconView.swift
@@ -30,6 +30,10 @@ struct FeedIconView: View {
     var style: Style = .standard
 
     @State private var iconImage: UIImage?
+    /// Background style resolved during on-view icon resolution. Takes
+    /// precedence over the model's `iconBackgroundStyle` (which may still
+    /// be `nil` until the next refresh cycle persists it).
+    @State private var resolvedBackgroundStyle: FeedIconBackgroundStyle?
 
     private static let logger = Logger(category: "FeedIconView")
 
@@ -56,10 +60,17 @@ struct FeedIconView: View {
         }
     }
 
+    /// The effective background classification, preferring a locally resolved
+    /// style (from on-view icon resolution) over the model's persisted value.
+    /// Falls back to `.none` when neither source has a classification yet.
+    private var effectiveBackgroundStyle: FeedIconBackgroundStyle? {
+        resolvedBackgroundStyle ?? iconBackgroundStyle
+    }
+
     /// The tile color that best contrasts against the cached icon (issue #342).
     /// `nil` → legacy black tile for feeds that predate the classifier.
     private var backgroundColor: Color {
-        switch iconBackgroundStyle {
+        switch effectiveBackgroundStyle {
         case .light: return .white
         case .dark, .none: return .black
         }
@@ -70,7 +81,7 @@ struct FeedIconView: View {
     /// sits on an icon — it only shows while loading or when no icon exists
     /// — so its color is chosen purely against the tile.
     private var placeholderForegroundColor: Color {
-        backgroundColor == .white ? .black.opacity(0.4) : .white.opacity(0.6)
+        effectiveBackgroundStyle == .light ? .black.opacity(0.4) : .white.opacity(0.6)
     }
 
     var body: some View {
@@ -137,17 +148,22 @@ struct FeedIconView: View {
             return
         }
 
-        let resolvedURL = await iconService.resolveAndCacheIcon(
+        let resolved = await iconService.resolveAndCacheIcon(
             feedSiteURL: feedSiteURL,
             feedImageURL: iconURL,
             feedID: feedID
         )
 
-        guard resolvedURL != nil else {
+        guard let resolved else {
             ImageLoadBackoffTracker.feedIcons.recordFailure(for: backoffKey)
             iconImage = nil
             return
         }
+
+        // Apply the classified background style immediately so the tile
+        // color is correct without waiting for the next refresh cycle to
+        // persist it to SwiftData.
+        resolvedBackgroundStyle = resolved.backgroundStyle
 
         // Successfully resolved — clear any prior backoff and reload from cache.
         ImageLoadBackoffTracker.feedIcons.clearFailure(for: backoffKey)

--- a/RSSAppTests/Mocks/MockFeedPersistenceService.swift
+++ b/RSSAppTests/Mocks/MockFeedPersistenceService.swift
@@ -484,7 +484,10 @@ final class MockFeedPersistenceService: FeedPersisting {
 
     // MARK: - Persistence
 
+    var saveCallCount = 0
+
     func save() throws {
         if let error = saveError ?? errorToThrow { throw error }
+        saveCallCount += 1
     }
 }

--- a/RSSAppTests/Services/FeedRefreshServiceTests.swift
+++ b/RSSAppTests/Services/FeedRefreshServiceTests.swift
@@ -452,13 +452,13 @@ struct FeedRefreshServiceTests {
             feedIconService: mockIconService
         )
 
-        let saveCountBefore = mockPersistence.saveCallCount
         await service.refreshAllFeeds()
-        for _ in 0..<10 { await Task.yield() }
+        let saveCountAfterRefresh = mockPersistence.saveCallCount
+        await service.awaitPendingWork()
 
-        // The fire-and-forget icon task must call save() so the
-        // backgroundStyle actually reaches the database.
-        #expect(mockPersistence.saveCallCount > saveCountBefore)
+        // The icon task must call save() beyond the main refresh save
+        // so the backgroundStyle actually reaches the database.
+        #expect(mockPersistence.saveCallCount > saveCountAfterRefresh)
         #expect(feed.iconBackgroundStyleRaw == "light")
     }
 
@@ -484,14 +484,14 @@ struct FeedRefreshServiceTests {
             feedIconService: mockIconService
         )
 
-        let saveCountBefore = mockPersistence.saveCallCount
         await service.refreshAllFeeds()
-        for _ in 0..<10 { await Task.yield() }
+        let saveCountAfterRefresh = mockPersistence.saveCallCount
+        await service.awaitPendingWork()
 
         #expect(mockIconService.classifyCachedIconCallCount == 1)
         #expect(feed.iconBackgroundStyleRaw == "light")
-        // The back-fill must call save() so the classification persists.
-        #expect(mockPersistence.saveCallCount > saveCountBefore)
+        // The back-fill must call save() beyond the main refresh save.
+        #expect(mockPersistence.saveCallCount > saveCountAfterRefresh)
     }
 
     @Test("refreshAllFeeds skips icon resolution when icon already cached")

--- a/RSSAppTests/Services/FeedRefreshServiceTests.swift
+++ b/RSSAppTests/Services/FeedRefreshServiceTests.swift
@@ -430,6 +430,70 @@ struct FeedRefreshServiceTests {
         #expect(feed.iconBackgroundStyleRaw == "light")
     }
 
+    @Test("refreshAllFeeds saves after persisting resolved icon")
+    @MainActor
+    func savesAfterIconResolution() async {
+        let url = URL(string: "https://example.com/feed")!
+        let feed = TestFixtures.makePersistentFeed(feedURL: url)
+
+        let mockPersistence = MockFeedPersistenceService()
+        mockPersistence.feeds = [feed]
+        let mockFetching = MockFeedFetchingService()
+        mockFetching.feedsByURL = [url: TestFixtures.makeFeed()]
+        let mockIconService = MockFeedIconService()
+        mockIconService.resolveAndCacheResult = (
+            url: URL(string: "https://example.com/icon.png")!,
+            backgroundStyle: .light
+        )
+
+        let service = Self.makeService(
+            persistence: mockPersistence,
+            feedFetching: mockFetching,
+            feedIconService: mockIconService
+        )
+
+        let saveCountBefore = mockPersistence.saveCallCount
+        await service.refreshAllFeeds()
+        for _ in 0..<10 { await Task.yield() }
+
+        // The fire-and-forget icon task must call save() so the
+        // backgroundStyle actually reaches the database.
+        #expect(mockPersistence.saveCallCount > saveCountBefore)
+        #expect(feed.iconBackgroundStyleRaw == "light")
+    }
+
+    @Test("refreshAllFeeds saves after back-filling icon classification")
+    @MainActor
+    func savesAfterIconBackFill() async {
+        let url = URL(string: "https://example.com/feed")!
+        let feed = TestFixtures.makePersistentFeed(feedURL: url)
+        // Simulate a feed with a cached icon but no classification yet
+        feed.iconBackgroundStyleRaw = nil
+
+        let mockPersistence = MockFeedPersistenceService()
+        mockPersistence.feeds = [feed]
+        let mockFetching = MockFeedFetchingService()
+        mockFetching.feedsByURL = [url: TestFixtures.makeFeed()]
+        let mockIconService = MockFeedIconService()
+        mockIconService.cachedFileURL = URL(fileURLWithPath: "/tmp/icon.png")
+        mockIconService.classifyCachedIconResult = .light
+
+        let service = Self.makeService(
+            persistence: mockPersistence,
+            feedFetching: mockFetching,
+            feedIconService: mockIconService
+        )
+
+        let saveCountBefore = mockPersistence.saveCallCount
+        await service.refreshAllFeeds()
+        for _ in 0..<10 { await Task.yield() }
+
+        #expect(mockIconService.classifyCachedIconCallCount == 1)
+        #expect(feed.iconBackgroundStyleRaw == "light")
+        // The back-fill must call save() so the classification persists.
+        #expect(mockPersistence.saveCallCount > saveCountBefore)
+    }
+
     @Test("refreshAllFeeds skips icon resolution when icon already cached")
     @MainActor
     func skipsIconResolutionWhenCached() async {


### PR DESCRIPTION
## Summary
- Feed icons appeared on incorrect black background tiles because `iconBackgroundStyleRaw` was never persisted to SwiftData
- The luminance classifier correctly computed the background style, but two code paths failed to apply it:
  1. **FeedRefreshService** fire-and-forget icon tasks modified the model after the main `persistence.save()` had already run — classification was lost every refresh cycle
  2. **FeedIconView** on-view resolution (the primary path on first launch) completely discarded the `backgroundStyle` from the resolution result
- All feeds fell through to `.none` → black tile, even icons like Meta, Reddit, Slack, Cloudflare, and NVIDIA that should display on white tiles based on their luminance

## Changes
- Add `persistence.save()` after both icon persistence paths in `FeedRefreshService.resolveAndCacheIconIfNeeded()` so each fire-and-forget task persists its own result
- Add `@State resolvedBackgroundStyle` to `FeedIconView` so on-view resolution applies the correct tile color immediately without waiting for the next refresh
- Add `effectiveBackgroundStyle` computed property that prefers the locally resolved style over the model's (possibly nil) persisted value
- Add `saveCallCount` tracking to `MockFeedPersistenceService`
- Add two tests pinning the save behavior for both icon persistence paths

## Test plan
- [x] `savesAfterIconResolution` — verifies `save()` is called after fresh icon resolution
- [x] `savesAfterIconBackFill` — verifies `save()` is called after back-filling cached icon classification
- [x] Full test suite passes
- [ ] On app launch, feed icons display with correct tile colors immediately
- [ ] After pull-to-refresh, `iconBackgroundStyleRaw` is populated in SwiftData

🤖 Generated with [Claude Code](https://claude.com/claude-code)