### PR TITLE
fix: Inject UserDefaults into view models to fix flaky sort tests (#401)

### DIFF
--- a/RSSApp/ViewModels/FeedViewModel.swift
+++ b/RSSApp/ViewModels/FeedViewModel.swift
@@ -29,12 +29,12 @@ final class FeedViewModel {
         }
     }
 
-    /// Current sort order — reads from the global UserDefaults preference.
+    /// Current sort order — reads from the injected UserDefaults instance.
     var sortAscending: Bool {
-        get { UserDefaults.standard.bool(forKey: Self.sortAscendingKey) }
+        get { userDefaults.bool(forKey: Self.sortAscendingKey) }
         set {
-            guard UserDefaults.standard.bool(forKey: Self.sortAscendingKey) != newValue else { return }
-            UserDefaults.standard.set(newValue, forKey: Self.sortAscendingKey)
+            guard userDefaults.bool(forKey: Self.sortAscendingKey) != newValue else { return }
+            userDefaults.set(newValue, forKey: Self.sortAscendingKey)
             Self.logger.debug("sortAscending changed to \(newValue, privacy: .public)")
             reloadArticles()
         }
@@ -42,16 +42,19 @@ final class FeedViewModel {
 
     private let feedFetching: FeedFetching
     private let persistence: FeedPersisting
+    private let userDefaults: UserDefaults
     let feed: PersistentFeed
 
     init(
         feed: PersistentFeed,
         feedFetching: FeedFetching = FeedFetchingService(),
-        persistence: FeedPersisting
+        persistence: FeedPersisting,
+        userDefaults: UserDefaults = .standard
     ) {
         self.feed = feed
         self.feedFetching = feedFetching
         self.persistence = persistence
+        self.userDefaults = userDefaults
         self.feedTitle = feed.title
     }
 

--- a/RSSApp/ViewModels/FeedViewModel.swift
+++ b/RSSApp/ViewModels/FeedViewModel.swift
@@ -7,7 +7,7 @@ final class FeedViewModel {
 
     private static let logger = Logger(category: "FeedViewModel")
 
-    /// UserDefaults key for the global sort order preference.
+    /// UserDefaults key for the app-wide sort order preference.
     static let sortAscendingKey = "articleSortAscending"
 
     /// Number of articles to fetch per page.
@@ -29,6 +29,11 @@ final class FeedViewModel {
         }
     }
 
+    // RATIONALE: sortAscending is a computed property backed by UserDefaults, so @Observable
+    // does not track it automatically. UI correctness is preserved because the setter calls
+    // reloadArticles(), which mutates the tracked `articles` array and drives SwiftUI updates.
+    // A Toggle bound to this property works fine: the setter fires on user interaction, and
+    // the resulting articles mutation triggers the necessary re-render.
     /// Current sort order — reads from the injected UserDefaults instance.
     var sortAscending: Bool {
         get { userDefaults.bool(forKey: Self.sortAscendingKey) }

--- a/RSSApp/ViewModels/HomeViewModel.swift
+++ b/RSSApp/ViewModels/HomeViewModel.swift
@@ -75,18 +75,19 @@ final class HomeViewModel {
     // to reload their own specific list. Callers toggle the property then call the
     // appropriate reload method (loadAllArticles, loadUnreadArticles, or
     // loadSavedArticles) for their view.
-    /// Current sort order — reads from the global UserDefaults preference.
+    /// Current sort order — reads from the injected UserDefaults instance.
     var sortAscending: Bool {
-        get { UserDefaults.standard.bool(forKey: FeedViewModel.sortAscendingKey) }
+        get { userDefaults.bool(forKey: FeedViewModel.sortAscendingKey) }
         set {
-            guard UserDefaults.standard.bool(forKey: FeedViewModel.sortAscendingKey) != newValue else { return }
-            UserDefaults.standard.set(newValue, forKey: FeedViewModel.sortAscendingKey)
+            guard userDefaults.bool(forKey: FeedViewModel.sortAscendingKey) != newValue else { return }
+            userDefaults.set(newValue, forKey: FeedViewModel.sortAscendingKey)
             Self.logger.debug("sortAscending changed to \(newValue, privacy: .public)")
         }
     }
 
     private let persistence: FeedPersisting
     private let badgeService: AppBadgeUpdating
+    private let userDefaults: UserDefaults
 
     /// Async closure that performs the actual network feed refresh.
     /// Returns an error message string on failure, or nil on success.
@@ -96,10 +97,12 @@ final class HomeViewModel {
     init(
         persistence: FeedPersisting,
         badgeService: AppBadgeUpdating = AppBadgeService(),
+        userDefaults: UserDefaults = .standard,
         refreshFeeds: (@Sendable () async -> String?)? = nil
     ) {
         self.persistence = persistence
         self.badgeService = badgeService
+        self.userDefaults = userDefaults
         self.refreshFeeds = refreshFeeds
     }
 

--- a/RSSAppTests/ViewModels/ArticleListSourceTests.swift
+++ b/RSSAppTests/ViewModels/ArticleListSourceTests.swift
@@ -166,9 +166,7 @@ struct ArticleListSourceTests {
     @Test("SavedArticlesSource.toggleSaved keeps the article in the list")
     @MainActor
     func savedArticlesSourceToggleSavedKeepsArticle() {
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
-        defer { UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey) }
-
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
         let feed = TestFixtures.makePersistentFeed()
         let mockPersistence = MockFeedPersistenceService()
         mockPersistence.feeds = [feed]
@@ -182,7 +180,7 @@ struct ArticleListSourceTests {
         saved.feed = feed
         mockPersistence.articlesByFeedID[feed.id] = [saved]
 
-        let viewModel = HomeViewModel(persistence: mockPersistence)
+        let viewModel = HomeViewModel(persistence: mockPersistence, userDefaults: defaults)
         let source = SavedArticlesSource(homeViewModel: viewModel)
 
         viewModel.loadSavedArticles()
@@ -205,9 +203,7 @@ struct ArticleListSourceTests {
     @Test("UnreadArticlesSource.markAllAsRead preserves the list snapshot")
     @MainActor
     func unreadArticlesSourceMarkAllAsReadPreservesSnapshot() {
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
-        defer { UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey) }
-
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
         let feed = TestFixtures.makePersistentFeed()
         let mockPersistence = MockFeedPersistenceService()
         mockPersistence.feeds = [feed]
@@ -226,7 +222,7 @@ struct ArticleListSourceTests {
         article2.feed = feed
         mockPersistence.articlesByFeedID[feed.id] = [article1, article2]
 
-        let viewModel = HomeViewModel(persistence: mockPersistence)
+        let viewModel = HomeViewModel(persistence: mockPersistence, userDefaults: defaults)
         let source = UnreadArticlesSource(homeViewModel: viewModel)
 
         viewModel.loadUnreadArticles()
@@ -354,8 +350,7 @@ struct ArticleListSourceTests {
     @Test("SavedArticlesSource.markAllAsRead only marks saved articles as read")
     @MainActor
     func savedArticlesSourceMarkAllAsReadScoped() {
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
-        defer { UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey) }
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
 
         let feed = TestFixtures.makePersistentFeed()
         let mockPersistence = MockFeedPersistenceService()
@@ -378,7 +373,7 @@ struct ArticleListSourceTests {
         unsavedUnread.feed = feed
         mockPersistence.articlesByFeedID[feed.id] = [saved, unsavedUnread]
 
-        let viewModel = HomeViewModel(persistence: mockPersistence)
+        let viewModel = HomeViewModel(persistence: mockPersistence, userDefaults: defaults)
         let source = SavedArticlesSource(homeViewModel: viewModel)
 
         viewModel.loadSavedArticles()

--- a/RSSAppTests/ViewModels/FeedViewModelTests.swift
+++ b/RSSAppTests/ViewModels/FeedViewModelTests.swift
@@ -311,7 +311,7 @@ struct FeedViewModelTests {
 
     /// Creates a loaded FeedViewModel with two articles for snapshot tests.
     /// Uses a fresh isolated UserDefaults suite so sort state does not bleed
-    /// across tests running in parallel on different suites.
+    /// across tests running in parallel.
     @MainActor
     private static func makeSnapshotFixture() async -> (
         viewModel: FeedViewModel,

--- a/RSSAppTests/ViewModels/FeedViewModelTests.swift
+++ b/RSSAppTests/ViewModels/FeedViewModelTests.swift
@@ -310,7 +310,8 @@ struct FeedViewModelTests {
     // MARK: - Stable List Snapshot
 
     /// Creates a loaded FeedViewModel with two articles for snapshot tests.
-    /// Cleans up UserDefaults before setup. Caller must clean up after test.
+    /// Uses a fresh isolated UserDefaults suite so sort state does not bleed
+    /// across tests running in parallel on different suites.
     @MainActor
     private static func makeSnapshotFixture() async -> (
         viewModel: FeedViewModel,
@@ -332,8 +333,8 @@ struct FeedViewModelTests {
 
         mock.feedToReturn = TestFixtures.makeFeed()
 
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
-        let viewModel = FeedViewModel(feed: feed, feedFetching: mock, persistence: mockPersistence)
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        let viewModel = FeedViewModel(feed: feed, feedFetching: mock, persistence: mockPersistence, userDefaults: defaults)
         await viewModel.loadFeed()
 
         return (viewModel, mockPersistence, article1, article2, feed)
@@ -350,8 +351,6 @@ struct FeedViewModelTests {
 
         #expect(article1.isRead == true)
         #expect(viewModel.articles.map(\.articleID) == idsBefore)
-
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
     }
 
     @Test("markAsRead does not change article list")
@@ -365,8 +364,6 @@ struct FeedViewModelTests {
 
         #expect(article1.isRead == true)
         #expect(viewModel.articles.map(\.articleID) == idsBefore)
-
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
     }
 
     /// Regression test for #209 (per-feed surface). When the user opens an article
@@ -406,8 +403,8 @@ struct FeedViewModelTests {
 
         mock.feedToReturn = TestFixtures.makeFeed()
 
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
-        let viewModel = FeedViewModel(feed: feed, feedFetching: mock, persistence: mockPersistence)
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        let viewModel = FeedViewModel(feed: feed, feedFetching: mock, persistence: mockPersistence, userDefaults: defaults)
         viewModel.showUnreadOnly = true
         await viewModel.loadFeed()
 
@@ -433,8 +430,6 @@ struct FeedViewModelTests {
         // Explicit reload (pull-to-refresh, sort/filter toggle, tab change) drops them.
         viewModel.reloadArticles()
         #expect(viewModel.articles.isEmpty)
-
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
     }
 
     @Test("reloadArticles refreshes list from persistence")
@@ -450,8 +445,6 @@ struct FeedViewModelTests {
 
         viewModel.reloadArticles()
         #expect(viewModel.articles.count == 3)
-
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
     }
 
     @Test("loadFeed clears error on successful retry")
@@ -522,9 +515,9 @@ struct FeedViewModelTests {
     @Test("sortAscending defaults to false (newest first)")
     @MainActor
     func sortAscendingDefault() {
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
         let feed = TestFixtures.makePersistentFeed()
-        let viewModel = FeedViewModel(feed: feed, feedFetching: MockFeedFetchingService(), persistence: MockFeedPersistenceService())
+        let viewModel = FeedViewModel(feed: feed, feedFetching: MockFeedFetchingService(), persistence: MockFeedPersistenceService(), userDefaults: defaults)
 
         #expect(viewModel.sortAscending == false)
     }
@@ -532,7 +525,7 @@ struct FeedViewModelTests {
     @Test("sortAscending toggle persists and reloads articles")
     @MainActor
     func sortAscendingToggleReloads() async {
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
         let feed = TestFixtures.makePersistentFeed(feedURL: URL(string: "https://example.com/feed")!)
         let mock = MockFeedFetchingService()
         let mockPersistence = MockFeedPersistenceService()
@@ -552,7 +545,7 @@ struct FeedViewModelTests {
 
         mock.feedToReturn = TestFixtures.makeFeed()
 
-        let viewModel = FeedViewModel(feed: feed, feedFetching: mock, persistence: mockPersistence)
+        let viewModel = FeedViewModel(feed: feed, feedFetching: mock, persistence: mockPersistence, userDefaults: defaults)
         await viewModel.loadFeed()
 
         // Default: newest first — article2 should be first
@@ -562,9 +555,6 @@ struct FeedViewModelTests {
         viewModel.sortAscending = true
 
         #expect(viewModel.articles.first?.articleID == "a1")
-
-        // Clean up
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
     }
 
     // MARK: - Read Filter
@@ -585,8 +575,8 @@ struct FeedViewModelTests {
 
         mock.feedToReturn = TestFixtures.makeFeed()
 
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
-        let viewModel = FeedViewModel(feed: feed, feedFetching: mock, persistence: mockPersistence)
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        let viewModel = FeedViewModel(feed: feed, feedFetching: mock, persistence: mockPersistence, userDefaults: defaults)
         await viewModel.loadFeed()
 
         #expect(viewModel.articles.count == 2)
@@ -600,9 +590,6 @@ struct FeedViewModelTests {
         viewModel.showUnreadOnly = false
 
         #expect(viewModel.articles.count == 2)
-
-        // Clean up
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
     }
 
     @Test("showUnreadOnly does not reload when set to same value")
@@ -647,8 +634,8 @@ struct FeedViewModelTests {
 
         mock.feedToReturn = TestFixtures.makeFeed()
 
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
-        let viewModel = FeedViewModel(feed: feed, feedFetching: mock, persistence: mockPersistence)
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        let viewModel = FeedViewModel(feed: feed, feedFetching: mock, persistence: mockPersistence, userDefaults: defaults)
         await viewModel.loadFeed()
 
         viewModel.markAllAsRead()
@@ -656,9 +643,6 @@ struct FeedViewModelTests {
         #expect(article1.isRead == true)
         #expect(article2.isRead == true)
         #expect(viewModel.errorMessage == nil)
-
-        // Clean up
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
     }
 
     @Test("markAllAsRead sets errorMessage on persistence failure")
@@ -690,8 +674,8 @@ struct FeedViewModelTests {
 
         mock.feedToReturn = TestFixtures.makeFeed()
 
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
-        let viewModel = FeedViewModel(feed: feed, feedFetching: mock, persistence: mockPersistence)
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        let viewModel = FeedViewModel(feed: feed, feedFetching: mock, persistence: mockPersistence, userDefaults: defaults)
         viewModel.showUnreadOnly = true
         await viewModel.loadFeed()
         #expect(viewModel.articles.count == 2)
@@ -704,9 +688,6 @@ struct FeedViewModelTests {
         // scroll position and currently-focused row are lost mid-action.
         #expect(viewModel.articles.count == 2)
         #expect(viewModel.articles.allSatisfy { $0.isRead })
-
-        // Clean up
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
     }
 
     // MARK: - Reload Error Paths
@@ -725,8 +706,8 @@ struct FeedViewModelTests {
 
         mock.feedToReturn = TestFixtures.makeFeed()
 
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
-        let viewModel = FeedViewModel(feed: feed, feedFetching: mock, persistence: mockPersistence)
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        let viewModel = FeedViewModel(feed: feed, feedFetching: mock, persistence: mockPersistence, userDefaults: defaults)
         await viewModel.loadFeed()
         #expect(viewModel.articles.count == 1)
 
@@ -736,9 +717,6 @@ struct FeedViewModelTests {
 
         #expect(viewModel.errorMessage == "Unable to reload articles.")
         #expect(viewModel.articles.count == 1, "Previous article list should be preserved on error")
-
-        // Clean up
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
     }
 
     @Test("reloadArticles sets errorMessage when persistence fails during sort toggle")
@@ -755,8 +733,8 @@ struct FeedViewModelTests {
 
         mock.feedToReturn = TestFixtures.makeFeed()
 
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
-        let viewModel = FeedViewModel(feed: feed, feedFetching: mock, persistence: mockPersistence)
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        let viewModel = FeedViewModel(feed: feed, feedFetching: mock, persistence: mockPersistence, userDefaults: defaults)
         await viewModel.loadFeed()
         #expect(viewModel.articles.count == 1)
 
@@ -766,9 +744,6 @@ struct FeedViewModelTests {
 
         #expect(viewModel.errorMessage == "Unable to reload articles.")
         #expect(viewModel.articles.count == 1, "Previous article list should be preserved on error")
-
-        // Clean up
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
     }
 
     @Test("reloadArticles direct call preserves list on persistence error")
@@ -782,8 +757,6 @@ struct FeedViewModelTests {
 
         #expect(viewModel.errorMessage == "Unable to reload articles.")
         #expect(viewModel.articles.count == 2, "Previous article list should be preserved on error")
-
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
     }
 
     // MARK: - Pagination with Unread Filter
@@ -818,8 +791,8 @@ struct FeedViewModelTests {
 
         mock.feedToReturn = TestFixtures.makeFeed()
 
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
-        let viewModel = FeedViewModel(feed: feed, feedFetching: mock, persistence: mockPersistence)
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        let viewModel = FeedViewModel(feed: feed, feedFetching: mock, persistence: mockPersistence, userDefaults: defaults)
         viewModel.showUnreadOnly = true
         await viewModel.loadFeed()
 
@@ -836,9 +809,6 @@ struct FeedViewModelTests {
         #expect(viewModel.hasMoreArticles == false)
         // Still no read article
         #expect(!viewModel.articles.contains { $0.articleID == "read1" })
-
-        // Clean up
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
     }
 
     // MARK: - Toggle Saved
@@ -1057,7 +1027,7 @@ struct FeedViewModelTests {
     @Test("reloadArticles preserves articleID prefix when network response overlaps cache")
     @MainActor
     func reloadArticlesPreservesArticleIDPrefix() async {
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
         let feed = TestFixtures.makePersistentFeed(feedURL: URL(string: "https://example.com/feed")!)
         let mock = MockFeedFetchingService()
         let mockPersistence = MockFeedPersistenceService()
@@ -1092,7 +1062,7 @@ struct FeedViewModelTests {
         }
         mock.feedToReturn = TestFixtures.makeFeed(articles: networkArticles)
 
-        let viewModel = FeedViewModel(feed: feed, feedFetching: mock, persistence: mockPersistence)
+        let viewModel = FeedViewModel(feed: feed, feedFetching: mock, persistence: mockPersistence, userDefaults: defaults)
         await viewModel.loadFeed()
 
         #expect(viewModel.articles.count == FeedViewModel.pageSize)
@@ -1103,8 +1073,6 @@ struct FeedViewModelTests {
 
         let prefixAfter = Array(viewModel.articles.prefix(FeedViewModel.pageSize)).map(\.articleID)
         #expect(prefixAfter == prefixBefore, "reloadArticles must preserve articleID identity for the previously loaded prefix")
-
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
     }
 
     /// Regression guard for #235. Companion to `reloadArticlesPreservesArticleIDPrefix`:
@@ -1115,7 +1083,7 @@ struct FeedViewModelTests {
     @Test("loadMoreAndReport preserves articleID for previously loaded prefix")
     @MainActor
     func loadMoreAndReportPreservesArticleIDPrefix() async {
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
         let feed = TestFixtures.makePersistentFeed(feedURL: URL(string: "https://example.com/feed")!)
         let mock = MockFeedFetchingService()
         let mockPersistence = MockFeedPersistenceService()
@@ -1135,7 +1103,7 @@ struct FeedViewModelTests {
         }
         mock.feedToReturn = TestFixtures.makeFeed(articles: articles)
 
-        let viewModel = FeedViewModel(feed: feed, feedFetching: mock, persistence: mockPersistence)
+        let viewModel = FeedViewModel(feed: feed, feedFetching: mock, persistence: mockPersistence, userDefaults: defaults)
         await viewModel.loadFeed()
 
         #expect(viewModel.articles.count == FeedViewModel.pageSize)
@@ -1147,8 +1115,6 @@ struct FeedViewModelTests {
 
         let prefixAfter = Array(viewModel.articles.prefix(FeedViewModel.pageSize)).map(\.articleID)
         #expect(prefixAfter == prefixBefore, "loadMoreAndReport must preserve articleID identity for the previously loaded prefix")
-
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
     }
 
     @Test("loadMoreArticles succeeds on retry after transient error")

--- a/RSSAppTests/ViewModels/GroupArticleSourceTests.swift
+++ b/RSSAppTests/ViewModels/GroupArticleSourceTests.swift
@@ -41,7 +41,10 @@ struct GroupArticleSourceTests {
             mock.articlesByFeedID[feed.id] = articles
         }
 
-        let homeVM = HomeViewModel(persistence: mock)
+        // Use an isolated UserDefaults suite so sort state changes in one test
+        // do not bleed into other tests running in parallel on different suites.
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        let homeVM = HomeViewModel(persistence: mock, userDefaults: defaults)
         let source = GroupArticleSource(group: group, persistence: mock, homeViewModel: homeVM)
         return (source, mock, group)
     }

--- a/RSSAppTests/ViewModels/HomeViewModelTests.swift
+++ b/RSSAppTests/ViewModels/HomeViewModelTests.swift
@@ -460,9 +460,8 @@ struct HomeViewModelTests {
 
         // Isolate from any ambient sort preference. The saved list now honors
         // the global sort toggle (sorted by sortDate with the stored direction)
-        // so leaving the pref unset from a previous test would flip ordering.
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
-        defer { UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey) }
+        // so leaving the pref set from a previous test would flip ordering.
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
 
         // Three saved articles, one already read, two unread. publishedDate is
         // used as the authoritative sort key under the new ordering (sortDate
@@ -494,7 +493,7 @@ struct HomeViewModelTests {
         saved3.feed = feed
         mockPersistence.articlesByFeedID[feed.id] = [saved1, saved2, saved3]
 
-        let viewModel = HomeViewModel(persistence: mockPersistence)
+        let viewModel = HomeViewModel(persistence: mockPersistence, userDefaults: defaults)
         viewModel.loadSavedArticles()
         let expectedOrder = ["s1", "s2", "s3"]
         #expect(viewModel.savedArticlesList.map(\.articleID) == expectedOrder)
@@ -964,27 +963,25 @@ struct HomeViewModelTests {
 
     // MARK: - Sort Order
 
-    @Test("sortAscending reads from UserDefaults via shared key")
+    @Test("sortAscending reads and writes through the injected UserDefaults instance")
     @MainActor
     func sortAscendingReadsSharedKey() {
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
         let mockPersistence = MockFeedPersistenceService()
-        let viewModel = HomeViewModel(persistence: mockPersistence)
+        let viewModel = HomeViewModel(persistence: mockPersistence, userDefaults: defaults)
 
         #expect(viewModel.sortAscending == false)
 
         viewModel.sortAscending = true
         #expect(viewModel.sortAscending == true)
-        #expect(UserDefaults.standard.bool(forKey: FeedViewModel.sortAscendingKey) == true)
-
-        // Clean up
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
+        #expect(defaults.bool(forKey: FeedViewModel.sortAscendingKey) == true)
     }
 
     @Test("loadAllArticles respects ascending sort order")
     @MainActor
     func loadAllArticlesAscending() {
-        UserDefaults.standard.set(true, forKey: FeedViewModel.sortAscendingKey)
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        defaults.set(true, forKey: FeedViewModel.sortAscendingKey)
         let feed = TestFixtures.makePersistentFeed()
         let mockPersistence = MockFeedPersistenceService()
         mockPersistence.feeds = [feed]
@@ -1001,21 +998,19 @@ struct HomeViewModelTests {
         article2.feed = feed
         mockPersistence.articlesByFeedID[feed.id] = [article1, article2]
 
-        let viewModel = HomeViewModel(persistence: mockPersistence)
+        let viewModel = HomeViewModel(persistence: mockPersistence, userDefaults: defaults)
         viewModel.loadAllArticles()
 
         // Ascending: oldest first
         #expect(viewModel.allArticlesList.first?.articleID == "a1")
         #expect(viewModel.allArticlesList.last?.articleID == "a2")
-
-        // Clean up
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
     }
 
     @Test("loadUnreadArticles respects ascending sort order")
     @MainActor
     func loadUnreadArticlesAscending() {
-        UserDefaults.standard.set(true, forKey: FeedViewModel.sortAscendingKey)
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        defaults.set(true, forKey: FeedViewModel.sortAscendingKey)
         let feed = TestFixtures.makePersistentFeed()
         let mockPersistence = MockFeedPersistenceService()
         mockPersistence.feeds = [feed]
@@ -1034,21 +1029,19 @@ struct HomeViewModelTests {
         article2.feed = feed
         mockPersistence.articlesByFeedID[feed.id] = [article1, article2]
 
-        let viewModel = HomeViewModel(persistence: mockPersistence)
+        let viewModel = HomeViewModel(persistence: mockPersistence, userDefaults: defaults)
         viewModel.loadUnreadArticles()
 
         // Ascending: oldest first
         #expect(viewModel.unreadArticlesList.first?.articleID == "u1")
         #expect(viewModel.unreadArticlesList.last?.articleID == "u2")
-
-        // Clean up
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
     }
 
     @Test("loadSavedArticles respects ascending sort order")
     @MainActor
     func loadSavedArticlesAscending() {
-        UserDefaults.standard.set(true, forKey: FeedViewModel.sortAscendingKey)
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        defaults.set(true, forKey: FeedViewModel.sortAscendingKey)
         let feed = TestFixtures.makePersistentFeed()
         let mockPersistence = MockFeedPersistenceService()
         mockPersistence.feeds = [feed]
@@ -1069,7 +1062,7 @@ struct HomeViewModelTests {
         article2.feed = feed
         mockPersistence.articlesByFeedID[feed.id] = [article1, article2]
 
-        let viewModel = HomeViewModel(persistence: mockPersistence)
+        let viewModel = HomeViewModel(persistence: mockPersistence, userDefaults: defaults)
         viewModel.loadSavedArticles()
 
         // Ascending: oldest sortDate first. savedDate is deliberately inverted
@@ -1077,9 +1070,6 @@ struct HomeViewModelTests {
         // (derived from publishedDate), not savedDate.
         #expect(viewModel.savedArticlesList.first?.articleID == "s1")
         #expect(viewModel.savedArticlesList.last?.articleID == "s2")
-
-        // Clean up
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
     }
 
     // MARK: - shouldRefreshOnEntry throttle
@@ -1171,8 +1161,8 @@ struct HomeViewModelTests {
         article2.feed = feed
         mockPersistence.articlesByFeedID[feed.id] = [article1, article2]
 
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
-        let viewModel = HomeViewModel(persistence: mockPersistence)
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        let viewModel = HomeViewModel(persistence: mockPersistence, userDefaults: defaults)
         viewModel.loadUnreadCount()
         #expect(viewModel.unreadCount == 2)
 
@@ -1190,9 +1180,6 @@ struct HomeViewModelTests {
         #expect(viewModel.unreadArticlesList.count == 2)
         #expect(viewModel.unreadArticlesList.allSatisfy { $0.isRead })
         #expect(viewModel.errorMessage == nil)
-
-        // Clean up
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
     }
 
     @Test("markAllAsRead sets errorMessage on persistence failure")
@@ -1218,8 +1205,8 @@ struct HomeViewModelTests {
         article.feed = feed
         mockPersistence.articlesByFeedID[feed.id] = [article]
 
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
-        let viewModel = HomeViewModel(persistence: mockPersistence)
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        let viewModel = HomeViewModel(persistence: mockPersistence, userDefaults: defaults)
         viewModel.loadUnreadArticles()
         #expect(viewModel.unreadArticlesList.count == 1)
 
@@ -1229,9 +1216,6 @@ struct HomeViewModelTests {
         // visible with isRead == true; the user can refresh to re-query.
         #expect(viewModel.unreadArticlesList.count == 1)
         #expect(viewModel.unreadArticlesList.first?.isRead == true)
-
-        // Clean up
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
     }
 
     @Test("markAllAsRead updates isRead on allArticlesList items without reloading")
@@ -1247,8 +1231,8 @@ struct HomeViewModelTests {
         article2.feed = feed
         mockPersistence.articlesByFeedID[feed.id] = [article1, article2]
 
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
-        let viewModel = HomeViewModel(persistence: mockPersistence)
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        let viewModel = HomeViewModel(persistence: mockPersistence, userDefaults: defaults)
         viewModel.loadAllArticles()
         #expect(viewModel.allArticlesList.count == 2)
 
@@ -1259,17 +1243,14 @@ struct HomeViewModelTests {
         // in place by the persistence layer's bulk mark-read operation.
         #expect(viewModel.allArticlesList.count == 2)
         #expect(viewModel.allArticlesList.allSatisfy { $0.isRead })
-
-        // Clean up
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
     }
 
     @Test("sortAscending setter is no-op when set to same value")
     @MainActor
     func sortAscendingSameValueNoOp() {
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
         let mockPersistence = MockFeedPersistenceService()
-        let viewModel = HomeViewModel(persistence: mockPersistence)
+        let viewModel = HomeViewModel(persistence: mockPersistence, userDefaults: defaults)
 
         #expect(viewModel.sortAscending == false)
 
@@ -1284,9 +1265,6 @@ struct HomeViewModelTests {
 
         viewModel.sortAscending = true
         #expect(viewModel.sortAscending == true)
-
-        // Clean up
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
     }
 
     // MARK: - Paginated Saved Articles
@@ -1822,7 +1800,7 @@ struct HomeViewModelTests {
     @Test("loadAllArticles preserves articleID prefix on reload")
     @MainActor
     func loadAllArticlesPreservesArticleIDPrefixOnReload() {
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
         let feed = TestFixtures.makePersistentFeed()
         let mockPersistence = MockFeedPersistenceService()
         mockPersistence.feeds = [feed]
@@ -1840,7 +1818,7 @@ struct HomeViewModelTests {
         }
         mockPersistence.articlesByFeedID[feed.id] = articles
 
-        let viewModel = HomeViewModel(persistence: mockPersistence)
+        let viewModel = HomeViewModel(persistence: mockPersistence, userDefaults: defaults)
         viewModel.loadAllArticles()
 
         #expect(viewModel.allArticlesList.count == HomeViewModel.pageSize)
@@ -1850,8 +1828,6 @@ struct HomeViewModelTests {
 
         let prefixAfter = Array(viewModel.allArticlesList.prefix(HomeViewModel.pageSize)).map(\.articleID)
         #expect(prefixAfter == prefixBefore, "loadAllArticles must preserve articleID identity for the previously loaded prefix")
-
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
     }
 
     /// Regression guard for #256. Companion to `loadAllArticlesPreservesArticleIDPrefixOnReload`:
@@ -1860,7 +1836,7 @@ struct HomeViewModelTests {
     @Test("loadMoreAllArticlesAndReport preserves articleID for previously loaded prefix")
     @MainActor
     func loadMoreAllArticlesAndReportPreservesArticleIDPrefix() {
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
         let feed = TestFixtures.makePersistentFeed()
         let mockPersistence = MockFeedPersistenceService()
         mockPersistence.feeds = [feed]
@@ -1876,7 +1852,7 @@ struct HomeViewModelTests {
         }
         mockPersistence.articlesByFeedID[feed.id] = articles
 
-        let viewModel = HomeViewModel(persistence: mockPersistence)
+        let viewModel = HomeViewModel(persistence: mockPersistence, userDefaults: defaults)
         viewModel.loadAllArticles()
 
         #expect(viewModel.allArticlesList.count == HomeViewModel.pageSize)
@@ -1888,8 +1864,6 @@ struct HomeViewModelTests {
 
         let prefixAfter = Array(viewModel.allArticlesList.prefix(HomeViewModel.pageSize)).map(\.articleID)
         #expect(prefixAfter == prefixBefore, "loadMoreAllArticlesAndReport must preserve articleID identity for the previously loaded prefix")
-
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
     }
 
     /// Regression guard for #256. Mirrors the all-articles variant for the unread pathway.
@@ -1898,7 +1872,7 @@ struct HomeViewModelTests {
     @Test("loadUnreadArticles preserves articleID prefix on reload")
     @MainActor
     func loadUnreadArticlesPreservesArticleIDPrefixOnReload() {
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
         let feed = TestFixtures.makePersistentFeed()
         let mockPersistence = MockFeedPersistenceService()
         mockPersistence.feeds = [feed]
@@ -1915,7 +1889,7 @@ struct HomeViewModelTests {
         }
         mockPersistence.articlesByFeedID[feed.id] = articles
 
-        let viewModel = HomeViewModel(persistence: mockPersistence)
+        let viewModel = HomeViewModel(persistence: mockPersistence, userDefaults: defaults)
         viewModel.loadUnreadArticles()
 
         #expect(viewModel.unreadArticlesList.count == HomeViewModel.pageSize)
@@ -1926,7 +1900,6 @@ struct HomeViewModelTests {
         let prefixAfter = Array(viewModel.unreadArticlesList.prefix(HomeViewModel.pageSize)).map(\.articleID)
         #expect(prefixAfter == prefixBefore, "loadUnreadArticles must preserve articleID identity for the previously loaded prefix")
 
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
     }
 
     /// Regression guard for #256. Companion to `loadUnreadArticlesPreservesArticleIDPrefixOnReload`:
@@ -1935,7 +1908,7 @@ struct HomeViewModelTests {
     @Test("loadMoreUnreadArticlesAndReport preserves articleID for previously loaded prefix")
     @MainActor
     func loadMoreUnreadArticlesAndReportPreservesArticleIDPrefix() {
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
         let feed = TestFixtures.makePersistentFeed()
         let mockPersistence = MockFeedPersistenceService()
         mockPersistence.feeds = [feed]
@@ -1952,7 +1925,7 @@ struct HomeViewModelTests {
         }
         mockPersistence.articlesByFeedID[feed.id] = articles
 
-        let viewModel = HomeViewModel(persistence: mockPersistence)
+        let viewModel = HomeViewModel(persistence: mockPersistence, userDefaults: defaults)
         viewModel.loadUnreadArticles()
 
         #expect(viewModel.unreadArticlesList.count == HomeViewModel.pageSize)
@@ -1964,8 +1937,6 @@ struct HomeViewModelTests {
 
         let prefixAfter = Array(viewModel.unreadArticlesList.prefix(HomeViewModel.pageSize)).map(\.articleID)
         #expect(prefixAfter == prefixBefore, "loadMoreUnreadArticlesAndReport must preserve articleID identity for the previously loaded prefix")
-
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
     }
 
     /// Regression guard for #256. Mirrors the all-articles variant for the saved-articles pathway.
@@ -1974,8 +1945,7 @@ struct HomeViewModelTests {
     @Test("loadSavedArticles preserves articleID prefix on reload")
     @MainActor
     func loadSavedArticlesPreservesArticleIDPrefixOnReload() {
-        UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey)
-        defer { UserDefaults.standard.removeObject(forKey: FeedViewModel.sortAscendingKey) }
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
         let feed = TestFixtures.makePersistentFeed()
         let mockPersistence = MockFeedPersistenceService()
         mockPersistence.feeds = [feed]
@@ -1993,7 +1963,7 @@ struct HomeViewModelTests {
         }
         mockPersistence.articlesByFeedID[feed.id] = articles
 
-        let viewModel = HomeViewModel(persistence: mockPersistence)
+        let viewModel = HomeViewModel(persistence: mockPersistence, userDefaults: defaults)
         viewModel.loadSavedArticles()
 
         #expect(viewModel.savedArticlesList.count == HomeViewModel.pageSize)

--- a/RSSAppTests/ViewModels/HomeViewModelTests.swift
+++ b/RSSAppTests/ViewModels/HomeViewModelTests.swift
@@ -458,9 +458,9 @@ struct HomeViewModelTests {
         let mockPersistence = MockFeedPersistenceService()
         mockPersistence.feeds = [feed]
 
-        // Isolate from any ambient sort preference. The saved list now honors
-        // the global sort toggle (sorted by sortDate with the stored direction)
-        // so leaving the pref set from a previous test would flip ordering.
+        // Use an isolated UserDefaults suite so sort state does not bleed across
+        // tests. The saved list honors the sort toggle (sorted by sortDate with
+        // the stored direction), so a stale pref from another test would flip ordering.
         let defaults = UserDefaults(suiteName: UUID().uuidString)!
 
         // Three saved articles, one already read, two unread. publishedDate is


### PR DESCRIPTION
## Summary
- `sortAscendingToggleReloads` (and related tests) failed intermittently because `UserDefaults.standard` sort state written in one test suite leaked into parallel suites. When the key was already `true`, the guard in `FeedViewModel.sortAscending.set` treated the toggle as a no-op and `reloadArticles()` was never called.
- Added a `userDefaults: UserDefaults = .standard` injection point to both `FeedViewModel` and `HomeViewModel`. Tests now pass a fresh `UserDefaults(suiteName: UUID().uuidString)` per test, giving each test full isolation without any production-code test seams.
- Also identified and fixed `GroupArticleSourceTests.sortAscendingToggle`, which was leaking `sortAscendingKey = true` to `UserDefaults.standard` and causing `HomeViewModelTests.readerSessionPreservesUnreadListSnapshot` to fail intermittently.

## Test plan
- [x] Full test suite passes (`** TEST SUCCEEDED **`)
- [x] `sortAscendingToggleReloads` exercises isolated defaults — the guard can no longer be tripped by leaked state
- [x] No production call sites require changes (default parameter preserves `UserDefaults.standard` behavior)

Closes #401