### PR TITLE
fix: Separate CancellationError from generic failures in resolveFromHTML

### DIFF
--- a/RSSApp/Services/FeedIconService.swift
+++ b/RSSApp/Services/FeedIconService.swift
@@ -607,6 +607,9 @@ struct FeedIconService: FeedIconResolving {
         } catch is CancellationError {
             Self.logger.debug("resolveFromHTML cancelled for \(siteURL.absoluteString, privacy: .public)")
             return nil
+        } catch let urlError as URLError where urlError.code == .cancelled {
+            Self.logger.debug("resolveFromHTML cancelled for \(siteURL.absoluteString, privacy: .public)")
+            return nil
         } catch {
             Self.logger.warning("Failed to fetch site HTML from \(siteURL.absoluteString, privacy: .public): \(error, privacy: .public)")
             return nil
@@ -946,6 +949,9 @@ struct FeedIconService: FeedIconResolving {
             }
 
             return (normalized, stats)
+        } catch is CancellationError {
+            Self.logger.debug("downloadAndAnalyze: download cancelled for \(url.absoluteString, privacy: .public)")
+            return nil
         } catch let error as URLError where error.code == .cancelled {
             Self.logger.debug("downloadAndAnalyze: download cancelled for \(url.absoluteString, privacy: .public)")
             return nil

--- a/RSSApp/Services/FeedIconService.swift
+++ b/RSSApp/Services/FeedIconService.swift
@@ -604,6 +604,9 @@ struct FeedIconService: FeedIconResolving {
                 ogImageURL: ogImageURL,
                 redirectedHost: redirectedHost
             )
+        } catch is CancellationError {
+            Self.logger.debug("resolveFromHTML cancelled for \(siteURL.absoluteString, privacy: .public)")
+            return nil
         } catch {
             Self.logger.warning("Failed to fetch site HTML from \(siteURL.absoluteString, privacy: .public): \(error, privacy: .public)")
             return nil


### PR DESCRIPTION
## Summary
- Prevent cancelled HTML fetches from being logged as feed resolution failures and incorrectly recorded as misses in `FeedIconMissTracker`
- `CancellationError` is now caught in a dedicated arm before the generic catch and logged at `.debug` level, matching the pattern already used in `downloadAndAnalyze()` for `URLError.cancelled`

Fixes #406

## Test plan
- [x] Build succeeded for iOS 26 Simulator
- [x] No new test seam required — cancellation is exercised through the normal task lifecycle