### PR TITLE
feat: Add in-flight request coalescing to FeedIconService (#402)

### DIFF
--- a/RSSApp/Services/FeedIconService.swift
+++ b/RSSApp/Services/FeedIconService.swift
@@ -127,6 +127,43 @@ actor FeedIconMissTracker {
     }
 }
 
+// MARK: - Resolution Coordinator
+
+/// Coalesces concurrent `resolveAndCacheIcon` requests for the same feed.
+/// The first caller for a given `feedID` creates the actual resolution task;
+/// subsequent callers await the same task instead of starting redundant network
+/// requests. The entry is removed once the task completes, so future requests
+/// (after cache invalidation, icon deletion, etc.) resolve fresh.
+actor FeedIconResolutionCoordinator {
+
+    private static let logger = Logger(category: "FeedIconResolutionCoordinator")
+
+    private var inFlight: [UUID: Task<(url: URL, backgroundStyle: FeedIconBackgroundStyle)?, Never>] = [:]
+
+    /// If a resolution for `feedID` is already in progress, awaits and returns
+    /// its result. Otherwise starts `work` and shares the result with all
+    /// concurrent callers for the same `feedID`.
+    func coalesce(
+        feedID: UUID,
+        work: @Sendable @escaping () async -> (url: URL, backgroundStyle: FeedIconBackgroundStyle)?
+    ) async -> (url: URL, backgroundStyle: FeedIconBackgroundStyle)? {
+        if let existing = inFlight[feedID] {
+            Self.logger.debug(
+                "Coalescing icon resolution for feed \(feedID.uuidString, privacy: .public) — awaiting in-flight task"
+            )
+            return await existing.value
+        }
+
+        let task = Task<(url: URL, backgroundStyle: FeedIconBackgroundStyle)?, Never> {
+            await work()
+        }
+        inFlight[feedID] = task
+        let result = await task.value
+        inFlight.removeValue(forKey: feedID)
+        return result
+    }
+}
+
 // MARK: - Implementation
 
 struct FeedIconService: FeedIconResolving {
@@ -159,9 +196,21 @@ struct FeedIconService: FeedIconResolving {
     /// instance; tests inject a dedicated instance for isolation.
     private let missTracker: FeedIconMissTracker
 
-    init(cacheDirectoryOverride: URL? = nil, missTracker: FeedIconMissTracker = .shared) {
+    /// Coalesces concurrent `resolveAndCacheIcon` requests for the same feed so
+    /// multiple concurrent callers (e.g. several `FeedIconView`s for the same feed)
+    /// share one in-flight network request instead of each starting their own.
+    /// Defaults to a shared app-wide instance; tests inject a dedicated instance
+    /// for isolation.
+    private let resolutionCoordinator: FeedIconResolutionCoordinator
+
+    init(
+        cacheDirectoryOverride: URL? = nil,
+        missTracker: FeedIconMissTracker = .shared,
+        resolutionCoordinator: FeedIconResolutionCoordinator = FeedIconResolutionCoordinator()
+    ) {
         self.cacheDirectoryOverride = cacheDirectoryOverride
         self.missTracker = missTracker
+        self.resolutionCoordinator = resolutionCoordinator
     }
 
     // MARK: - FeedIconResolving
@@ -220,6 +269,16 @@ struct FeedIconService: FeedIconResolving {
     }
 
     func resolveAndCacheIcon(feedSiteURL: URL?, feedImageURL: URL?, feedID: UUID) async -> (url: URL, backgroundStyle: FeedIconBackgroundStyle)? {
+        await resolutionCoordinator.coalesce(feedID: feedID) { [self] in
+            await self.performResolveAndCacheIcon(
+                feedSiteURL: feedSiteURL,
+                feedImageURL: feedImageURL,
+                feedID: feedID
+            )
+        }
+    }
+
+    private func performResolveAndCacheIcon(feedSiteURL: URL?, feedImageURL: URL?, feedID: UUID) async -> (url: URL, backgroundStyle: FeedIconBackgroundStyle)? {
         Self.logger.debug("resolveAndCacheIcon() for feed \(feedID.uuidString, privacy: .public)")
 
         // Fetch site HTML to discover link icons

--- a/RSSApp/Services/FeedIconService.swift
+++ b/RSSApp/Services/FeedIconService.swift
@@ -136,6 +136,8 @@ actor FeedIconMissTracker {
 /// (after cache invalidation, icon deletion, etc.) resolve fresh.
 actor FeedIconResolutionCoordinator {
 
+    static let shared = FeedIconResolutionCoordinator()
+
     private static let logger = Logger(category: "FeedIconResolutionCoordinator")
 
     private var inFlight: [UUID: Task<(url: URL, backgroundStyle: FeedIconBackgroundStyle)?, Never>] = [:]
@@ -143,6 +145,15 @@ actor FeedIconResolutionCoordinator {
     /// If a resolution for `feedID` is already in progress, awaits and returns
     /// its result. Otherwise starts `work` and shares the result with all
     /// concurrent callers for the same `feedID`.
+    ///
+    /// When multiple callers arrive concurrently, only the first caller's `work`
+    /// closure is executed; subsequent callers' `work` closures are never called —
+    /// they receive the result from the first caller's closure instead.
+    ///
+    /// This works because `await task.value` suspends the actor, allowing
+    /// subsequent callers to enter `coalesce` and find the existing in-flight
+    /// entry before the first task completes. Callers that arrive after the task
+    /// finishes (and the entry is removed) start a fresh resolution.
     func coalesce(
         feedID: UUID,
         work: @Sendable @escaping () async -> (url: URL, backgroundStyle: FeedIconBackgroundStyle)?
@@ -206,7 +217,7 @@ struct FeedIconService: FeedIconResolving {
     init(
         cacheDirectoryOverride: URL? = nil,
         missTracker: FeedIconMissTracker = .shared,
-        resolutionCoordinator: FeedIconResolutionCoordinator = FeedIconResolutionCoordinator()
+        resolutionCoordinator: FeedIconResolutionCoordinator = .shared
     ) {
         self.cacheDirectoryOverride = cacheDirectoryOverride
         self.missTracker = missTracker

--- a/RSSAppTests/Services/FeedIconResolutionCoordinatorTests.swift
+++ b/RSSAppTests/Services/FeedIconResolutionCoordinatorTests.swift
@@ -68,6 +68,82 @@ struct FeedIconResolutionCoordinatorTests {
         #expect(invokeCount == feedIDs.count, "Work closure should run once per distinct feedID; ran \(invokeCount) times for \(feedIDs.count) feeds")
     }
 
+    /// Single-shot async gate: the sender calls `signal()` once; the receiver
+    /// calls `wait()` and suspends until the signal arrives.
+    private actor Gate {
+        private var continuation: CheckedContinuation<Void, Never>?
+        private var signalled = false
+
+        func signal() {
+            if let c = continuation {
+                c.resume()
+                continuation = nil
+            } else {
+                signalled = true
+            }
+        }
+
+        func wait() async {
+            if signalled { return }
+            await withCheckedContinuation { continuation = $0 }
+        }
+    }
+
+    @Test("Cancelling one awaiter does not cancel the shared task or other awaiters")
+    func cancellingOneAwaiterDoesNotCancelSharedTask() async {
+        let coordinator = FeedIconResolutionCoordinator()
+        let counter = CallCounter()
+        let feedID = UUID()
+        let expectedURL = URL(string: "https://example.com/icon.png")!
+        let expectedStyle = FeedIconBackgroundStyle.light
+
+        // Gate that lets the test cancel task B only after the work closure has started.
+        let gate = Gate()
+
+        // Task A: first caller — owns the work closure. Signals the gate when it
+        // starts so we can cancel task B while the work is still in progress.
+        let taskA = Task {
+            await coordinator.coalesce(feedID: feedID) {
+                await counter.increment()
+                await gate.signal()
+                try? await Task.sleep(for: .milliseconds(100))
+                return (url: expectedURL, backgroundStyle: expectedStyle)
+            }
+        }
+
+        // Wait until the work closure is running before launching and cancelling task B.
+        await gate.wait()
+
+        // Task B: concurrent caller that arrives while the work is in progress.
+        // It awaits the shared task; cancelling it must not cancel the coordinator's
+        // unstructured Task, which is not a child of task B.
+        let taskB = Task {
+            await coordinator.coalesce(feedID: feedID) {
+                // This closure must never run — task B awaits task A's result.
+                await counter.increment()
+                return nil
+            }
+        }
+        taskB.cancel()
+
+        // Task C: another concurrent caller that must still receive the correct result.
+        let taskC = Task {
+            await coordinator.coalesce(feedID: feedID) {
+                await counter.increment()
+                return nil
+            }
+        }
+
+        let resultA = await taskA.value
+        _ = await taskB.value
+        let resultC = await taskC.value
+
+        let invokeCount = await counter.count
+        #expect(invokeCount == 1, "Work closure should run exactly once; ran \(invokeCount) times")
+        #expect(resultA?.url == expectedURL, "Task A should receive the resolved URL")
+        #expect(resultC?.url == expectedURL, "Task C should receive the resolved URL despite task B being cancelled")
+    }
+
     @Test("Completed entry is removed, allowing a fresh resolution on the next call")
     func completedEntryRemovedAllowsFreshResolution() async {
         let coordinator = FeedIconResolutionCoordinator()

--- a/RSSAppTests/Services/FeedIconResolutionCoordinatorTests.swift
+++ b/RSSAppTests/Services/FeedIconResolutionCoordinatorTests.swift
@@ -1,0 +1,92 @@
+import Testing
+import Foundation
+@testable import RSSApp
+
+@Suite("FeedIconResolutionCoordinator Tests")
+struct FeedIconResolutionCoordinatorTests {
+
+    // MARK: - Helpers
+
+    /// Thread-safe counter used to verify how many times the work closure was invoked.
+    private actor CallCounter {
+        private(set) var count = 0
+
+        func increment() {
+            count += 1
+        }
+    }
+
+    // MARK: - Tests
+
+    @Test("Concurrent calls for the same feedID coalesce to a single work invocation")
+    func concurrentCallsForSameFeedIDCoalesce() async {
+        let coordinator = FeedIconResolutionCoordinator()
+        let counter = CallCounter()
+        let feedID = UUID()
+        let expectedURL = URL(string: "https://example.com/icon.png")!
+        let expectedStyle = FeedIconBackgroundStyle.light
+
+        // Launch 5 tasks simultaneously for the same feedID.
+        // The work closure delays 50ms so all callers are guaranteed to arrive
+        // before the first task completes, ensuring coalescing is exercised.
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<5 {
+                group.addTask {
+                    let result = await coordinator.coalesce(feedID: feedID) {
+                        await counter.increment()
+                        try? await Task.sleep(for: .milliseconds(50))
+                        return (url: expectedURL, backgroundStyle: expectedStyle)
+                    }
+                    #expect(result?.url == expectedURL)
+                    #expect(result?.backgroundStyle == expectedStyle)
+                }
+            }
+        }
+
+        let invokeCount = await counter.count
+        #expect(invokeCount == 1, "Work closure should run exactly once for coalesced calls; ran \(invokeCount) times")
+    }
+
+    @Test("Concurrent calls for different feedIDs proceed independently")
+    func concurrentCallsForDifferentFeedIDsProceedIndependently() async {
+        let coordinator = FeedIconResolutionCoordinator()
+        let counter = CallCounter()
+        let feedIDs = [UUID(), UUID(), UUID()]
+
+        await withTaskGroup(of: Void.self) { group in
+            for feedID in feedIDs {
+                group.addTask {
+                    _ = await coordinator.coalesce(feedID: feedID) {
+                        await counter.increment()
+                        return nil
+                    }
+                }
+            }
+        }
+
+        let invokeCount = await counter.count
+        #expect(invokeCount == feedIDs.count, "Work closure should run once per distinct feedID; ran \(invokeCount) times for \(feedIDs.count) feeds")
+    }
+
+    @Test("Completed entry is removed, allowing a fresh resolution on the next call")
+    func completedEntryRemovedAllowsFreshResolution() async {
+        let coordinator = FeedIconResolutionCoordinator()
+        let counter = CallCounter()
+        let feedID = UUID()
+
+        // First call — completes normally.
+        _ = await coordinator.coalesce(feedID: feedID) {
+            await counter.increment()
+            return nil
+        }
+
+        // Second call — must start fresh because the first entry was removed on completion.
+        _ = await coordinator.coalesce(feedID: feedID) {
+            await counter.increment()
+            return nil
+        }
+
+        let invokeCount = await counter.count
+        #expect(invokeCount == 2, "Work closure should run again after the first resolution completed; ran \(invokeCount) times")
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `FeedIconResolutionCoordinator`, a new actor that coalesces concurrent `resolveAndCacheIcon()` calls for the same feed into a single in-flight network request
- Prevents the observed scenario where multiple `FeedIconView` instances (or an on-view load racing a background refresh) each independently triggered full icon resolution for the same feed, causing duplicate downloads within milliseconds of each other
- The coordinator is held as a stored property on `FeedIconService` and is init-injectable for test isolation, following the same pattern as `FeedIconMissTracker`

Fixes #402

## Changes
- `RSSApp/Services/FeedIconService.swift`: Add `FeedIconResolutionCoordinator` actor; add `resolutionCoordinator` property to `FeedIconService` with updated `init`; wrap public `resolveAndCacheIcon()` as a coordinator delegate, moving the resolution logic to private `performResolveAndCacheIcon()`
- `RSSAppTests/Services/FeedIconResolutionCoordinatorTests.swift`: New test file with 3 tests covering the explicit issue requirements

## Test plan
- [x] Built successfully for iOS 26
- [x] `FeedIconResolutionCoordinatorTests`: 3/3 pass — concurrent same-feedID coalescing, independent different-feedIDs, and fresh resolution after completion
- [x] `FeedIconServiceTests`: all existing tests pass with no regressions