### PR TITLE
fix: Expand tap target for group membership toggles in Edit Feed view

### DIFF
--- a/RSSApp/Views/EditFeedView.swift
+++ b/RSSApp/Views/EditFeedView.swift
@@ -45,6 +45,7 @@ struct EditFeedView: View {
                                             .foregroundStyle(.tint)
                                     }
                                 }
+                                .contentShape(Rectangle())
                             }
                             .buttonStyle(.plain)
                         }


### PR DESCRIPTION
## Summary
- Tapping anywhere on a group row (including empty space and the checkmark area) in the Edit Feed sheet now toggles group membership
- No visual or behavioral changes otherwise

## Changes
- Added `.contentShape(Rectangle())` to the `HStack` inside the group membership `Button` label in `EditFeedView.swift` so the full row width registers taps, not just the rendered label content

## Test plan
- [ ] Built successfully for iOS 26
- [ ] Tapping white space to the right of a group name in Edit Feed sheet toggles membership
- [ ] Tapping the checkmark area toggles membership
- [ ] Visual appearance of group rows is unchanged

Fixes #409