### PR TITLE
fix: Persist on-view icon background style to model to survive scroll cycles (#411)

### DIFF
--- a/RSSApp/Views/ArticleRowView.swift
+++ b/RSSApp/Views/ArticleRowView.swift
@@ -111,7 +111,10 @@ struct ArticleRowView: View {
                     iconURL: feed.iconURL,
                     iconBackgroundStyle: feed.iconBackgroundStyle,
                     iconService: iconService,
-                    style: .inline
+                    style: .inline,
+                    onBackgroundStyleResolved: { style in
+                        feed.iconBackgroundStyle = style
+                    }
                 )
                 Text(feed.title)
             }

--- a/RSSApp/Views/FeedIconView.swift
+++ b/RSSApp/Views/FeedIconView.swift
@@ -32,12 +32,15 @@ struct FeedIconView: View {
     let iconBackgroundStyle: FeedIconBackgroundStyle?
     let iconService: FeedIconResolving
     var style: Style = .standard
+    /// Called after successful on-view icon resolution so the caller can
+    /// persist the background style to the model. Both the refresh path and
+    /// the on-view path write to the same store; the view reads only from
+    /// `iconBackgroundStyle` (the model parameter), eliminating the ephemeral
+    /// `@State` bridge that caused backgrounds to revert to black on
+    /// scroll-back (issue #411).
+    var onBackgroundStyleResolved: ((FeedIconBackgroundStyle) -> Void)? = nil
 
     @State private var iconImage: UIImage?
-    /// Background style resolved during on-view icon resolution. Takes
-    /// precedence over the model's `iconBackgroundStyle` (which may still
-    /// be `nil` until the next refresh cycle persists it).
-    @State private var resolvedBackgroundStyle: FeedIconBackgroundStyle?
 
     private static let logger = Logger(category: "FeedIconView")
 
@@ -64,19 +67,12 @@ struct FeedIconView: View {
         }
     }
 
-    /// The effective background classification, preferring a locally resolved
-    /// style (from on-view icon resolution) over the model's persisted value.
-    /// Falls back to `.none` when neither source has a classification yet.
-    private var effectiveBackgroundStyle: FeedIconBackgroundStyle? {
-        resolvedBackgroundStyle ?? iconBackgroundStyle
-    }
-
     /// The tile color that best contrasts against a loaded icon (issue #342).
     /// Only applied when `iconImage` is non-nil; the placeholder always
     /// uses a white tile (see `body`). `nil` → legacy black for feeds
     /// that predate the classifier.
     private var backgroundColor: Color {
-        switch effectiveBackgroundStyle {
+        switch iconBackgroundStyle {
         case .light: return .white
         case .dark, .none: return .black
         }
@@ -160,11 +156,6 @@ struct FeedIconView: View {
             return
         }
 
-        // Apply the classified background style immediately so the tile
-        // color is correct without waiting for the next refresh cycle to
-        // persist it to SwiftData.
-        resolvedBackgroundStyle = resolved.backgroundStyle
-
         // Successfully resolved — clear any prior backoff and reload from cache.
         ImageLoadBackoffTracker.feedIcons.clearFailure(for: backoffKey)
         Self.logger.notice("Resolved icon on-view for feed \(feedID.uuidString, privacy: .public)")
@@ -173,5 +164,12 @@ struct FeedIconView: View {
             Self.logger.warning("Icon resolved for feed \(feedID.uuidString, privacy: .public) but failed post-cache validation")
         }
         iconImage = validated
+
+        // Persist the background style to the model so it survives view
+        // destruction across scroll cycles. The refresh path persists via
+        // applyIconResolution(); this is the on-view equivalent. Image is
+        // set first so the view is fully populated before the model update
+        // triggers a re-render.
+        onBackgroundStyleResolved?(resolved.backgroundStyle)
     }
 }

--- a/RSSApp/Views/FeedIconView.swift
+++ b/RSSApp/Views/FeedIconView.swift
@@ -33,8 +33,8 @@ struct FeedIconView: View {
     let iconService: FeedIconResolving
     var style: Style = .standard
     /// Called after successful on-view icon resolution so the caller can
-    /// persist the background style to the model. Both the refresh path and
-    /// the on-view path write to the same store; the view reads only from
+    /// persist the background style to the model. Both paths ultimately mutate
+    /// `PersistentFeed.iconBackgroundStyle`; the view reads only from
     /// `iconBackgroundStyle` (the model parameter), eliminating the ephemeral
     /// `@State` bridge that caused backgrounds to revert to black on
     /// scroll-back (issue #411).
@@ -168,8 +168,8 @@ struct FeedIconView: View {
         // Persist the background style to the model so it survives view
         // destruction across scroll cycles. The refresh path persists via
         // applyIconResolution(); this is the on-view equivalent. Image is
-        // set first so the view is fully populated before the model update
-        // triggers a re-render.
+        // set first so the view's local state is consistent before the
+        // caller persists the background style to the model.
         onBackgroundStyleResolved?(resolved.backgroundStyle)
     }
 }

--- a/RSSApp/Views/FeedRowView.swift
+++ b/RSSApp/Views/FeedRowView.swift
@@ -13,7 +13,10 @@ struct FeedRowView: View {
                 feedImageURL: feed.feedImageURL,
                 iconURL: feed.iconURL,
                 iconBackgroundStyle: feed.iconBackgroundStyle,
-                iconService: iconService
+                iconService: iconService,
+                onBackgroundStyleResolved: { style in
+                    feed.iconBackgroundStyle = style
+                }
             )
 
             VStack(alignment: .leading, spacing: 4) {


### PR DESCRIPTION
## Summary
- Feed icon backgrounds no longer revert to black after scrolling away and back
- Eliminates the ephemeral `@State resolvedBackgroundStyle` bridge in `FeedIconView` — the model's `iconBackgroundStyle` is now the single source of truth for both the refresh path and the on-view resolution path

## Root cause
On-view resolution stored the classified background style only in `@State` (destroyed when SwiftUI destroys the off-screen view). On scroll-back, the cache-hit path loaded the image but `iconBackgroundStyle` was still `nil` on the model, so `backgroundColor` fell back to black.

## Changes
- **`FeedIconView.swift`**: Added `onBackgroundStyleResolved` closure parameter; removed `@State resolvedBackgroundStyle` and `effectiveBackgroundStyle`; `backgroundColor` now reads directly from `iconBackgroundStyle`; closure is called after successful on-view resolution (after `iconImage` is set to avoid a placeholder flash on the re-render)
- **`FeedRowView.swift`**: Passes `onBackgroundStyleResolved` closure writing `feed.iconBackgroundStyle`
- **`ArticleRowView.swift`**: Passes `onBackgroundStyleResolved` closure writing `feed.iconBackgroundStyle`

Since `PersistentFeed` is `@Model`, the property assignment is tracked by SwiftData's `ModelContext` and auto-saved — no explicit `save()` needed.

Closes #411