### PR TITLE
fix: Suppress expected BGTaskScheduler.unavailable errors on Simulator

### DIFF
--- a/RSSApp/App/RSSAppApp.swift
+++ b/RSSApp/App/RSSAppApp.swift
@@ -1,3 +1,4 @@
+import BackgroundTasks
 import SwiftUI
 import SwiftData
 import os
@@ -96,6 +97,10 @@ struct RSSAppApp: App {
             // (which does surface failures).
             do {
                 try BackgroundRefreshScheduler.scheduleNextRefresh()
+            } catch let error as BGTaskScheduler.Error where error.code == .unavailable {
+                // .unavailable is expected on Simulator and when Background App
+                // Refresh is disabled in Settings. Log at .debug — not a bug.
+                Self.logger.debug("Background refresh unavailable at launch (Simulator or Background App Refresh disabled): \(error, privacy: .public)")
             } catch {
                 Self.logger.error("Failed to seed background refresh at launch: \(error, privacy: .public)")
             }

--- a/RSSApp/Services/BackgroundRefreshScheduler.swift
+++ b/RSSApp/Services/BackgroundRefreshScheduler.swift
@@ -82,12 +82,27 @@ enum BackgroundRefreshScheduler {
         }
 
         if !appRefreshRegistered {
+            // RATIONALE: BGTaskScheduler.register always returns false on Simulator
+            // (Apple does not support BGTaskScheduler there). assertionFailure is
+            // suppressed on Simulator to avoid crashing every debug launch for an
+            // expected, non-actionable condition; the .fault log is downgraded to
+            // .debug so it remains visible when streaming but doesn't pollute the
+            // console on routine runs.
+            #if targetEnvironment(simulator)
+            logger.debug("BGAppRefreshTask registration returned false on Simulator (expected — BGTaskScheduler is unavailable on Simulator)")
+            #else
             logger.fault("Failed to register BGAppRefreshTask identifier '\(appRefreshTaskIdentifier, privacy: .public)' — check Info.plist BGTaskSchedulerPermittedIdentifiers")
             assertionFailure("Failed to register BGAppRefreshTask identifier '\(appRefreshTaskIdentifier)': check Info.plist BGTaskSchedulerPermittedIdentifiers")
+            #endif
         }
         if !processingRegistered {
+            // RATIONALE: Same as appRefreshRegistered above — expected false on Simulator.
+            #if targetEnvironment(simulator)
+            logger.debug("BGProcessingTask registration returned false on Simulator (expected — BGTaskScheduler is unavailable on Simulator)")
+            #else
             logger.fault("Failed to register BGProcessingTask identifier '\(processingTaskIdentifier, privacy: .public)' — check Info.plist BGTaskSchedulerPermittedIdentifiers")
             assertionFailure("Failed to register BGProcessingTask identifier '\(processingTaskIdentifier)': check Info.plist BGTaskSchedulerPermittedIdentifiers")
+            #endif
         }
         logger.notice("Background task launch handlers registered")
     }
@@ -185,6 +200,13 @@ enum BackgroundRefreshScheduler {
         do {
             try BGTaskScheduler.shared.submit(request)
             logger.notice("Submitted background refresh request '\(request.identifier, privacy: .public)' earliestBeginDate=\(request.earliestBeginDate?.description ?? "nil", privacy: .public)")
+        } catch let error as BGTaskScheduler.Error where error.code == .unavailable {
+            // .unavailable is expected on Simulator and when the user has disabled
+            // Background App Refresh in Settings — neither is a bug. Log at .debug
+            // so it's visible when actively streaming logs but doesn't surface as
+            // an error in routine operation.
+            logger.debug("Background refresh submission unavailable for '\(request.identifier, privacy: .public)' (Simulator or Background App Refresh disabled in Settings): \(error, privacy: .public)")
+            throw error
         } catch {
             logger.error("Failed to submit background refresh request '\(request.identifier, privacy: .public)': \(error, privacy: .public)")
             throw error


### PR DESCRIPTION
## Summary
- `BGTaskScheduler.register()` and `submit()` always fail with `.unavailable` on Simulator and when Background App Refresh is disabled in Settings — these are expected, non-actionable conditions, not bugs
- The previous code logged these at `.error` / `.fault` level and fired `assertionFailure` on every Simulator debug launch, producing misleading console noise

## Changes
- `BackgroundRefreshScheduler.submit(_:)`: catch `BGTaskScheduler.Error.unavailable` specifically and log at `.debug`; all other failures still log at `.error`
- `BackgroundRefreshScheduler.registerLaunchHandlers()`: wrap `assertionFailure` calls in `#if !targetEnvironment(simulator)` and downgrade to `.debug` logging on Simulator; device builds retain the `.fault` + `assertionFailure` behavior
- `RSSAppApp.init()`: import `BackgroundTasks` and split the launch-seed catch into a `.unavailable`-specific branch (`.debug`) and a catch-all (`.error`)

## Test plan
- [x] Built successfully for iOS 26 Simulator
- [x] All existing tests pass

Closes #412