### PR TITLE
fix: Skip missTracker.recordMiss() in resolveAndCacheIcon when task is cancelled

### DIFF
--- a/RSSApp/Services/FeedIconService.swift
+++ b/RSSApp/Services/FeedIconService.swift
@@ -353,6 +353,7 @@ struct FeedIconService: FeedIconResolving {
         }
 
         guard !downloadedCandidates.isEmpty else {
+            guard !Task.isCancelled else { return nil }
             let missCount = await missTracker.recordMiss(for: feedID)
             if missCount == FeedIconMissTracker.missThreshold {
                 Self.logger.warning(
@@ -406,6 +407,7 @@ struct FeedIconService: FeedIconResolving {
             }
         }
 
+        guard !Task.isCancelled else { return nil }
         let missCount = await missTracker.recordMiss(for: feedID)
         if missCount == FeedIconMissTracker.missThreshold {
             Self.logger.warning(

--- a/RSSApp/Services/FeedIconService.swift
+++ b/RSSApp/Services/FeedIconService.swift
@@ -353,7 +353,10 @@ struct FeedIconService: FeedIconResolving {
         }
 
         guard !downloadedCandidates.isEmpty else {
-            guard !Task.isCancelled else { return nil }
+            guard !Task.isCancelled else {
+                Self.logger.debug("Skipping miss recording for feed \(feedID.uuidString, privacy: .public) — task cancelled (no candidates downloaded)")
+                return nil
+            }
             let missCount = await missTracker.recordMiss(for: feedID)
             if missCount == FeedIconMissTracker.missThreshold {
                 Self.logger.warning(
@@ -407,7 +410,10 @@ struct FeedIconService: FeedIconResolving {
             }
         }
 
-        guard !Task.isCancelled else { return nil }
+        guard !Task.isCancelled else {
+            Self.logger.debug("Skipping miss recording for feed \(feedID.uuidString, privacy: .public) — task cancelled (all candidates failed)")
+            return nil
+        }
         let missCount = await missTracker.recordMiss(for: feedID)
         if missCount == FeedIconMissTracker.missThreshold {
             Self.logger.warning(


### PR DESCRIPTION
## Summary
- Prevents spurious miss accumulation when icon resolution tasks are cancelled (e.g. navigating away before resolution completes)
- Avoids misleading chronic-failure `.warning` log entries for feeds whose icons are simply not yet loaded, not genuinely broken

## Changes
- Added `guard !Task.isCancelled else { return nil }` before each `missTracker.recordMiss()` call in `performResolveAndCacheIcon()` — the no-candidates-downloaded path and the all-candidates-failed-scoring path

## Test plan
- [ ] Built successfully for iOS 26
- [ ] All existing tests pass
- [ ] Verify no spurious chronic-failure warnings in logs after quickly navigating away from feeds

Closes #416