### PR TITLE
fix: Inject UserDefaults into FeedRefreshService to fix shouldRefreshOnEntry test leakage (#422)

### DIFF
--- a/RSSApp/Services/FeedRefreshService.swift
+++ b/RSSApp/Services/FeedRefreshService.swift
@@ -28,16 +28,6 @@ final class FeedRefreshService {
     /// entry refreshes even when the previous refresh came from a `BGTask`.
     static let lastRefreshCompletedKey = "feedRefresh.lastCompletedAt"
 
-    /// Wall-clock timestamp of the most recent `.completed` refresh outcome,
-    /// across any caller in the process. `nil` when no refresh has ever
-    /// completed on this install. Read by `HomeViewModel.shouldRefreshOnEntry`
-    /// to decide whether a cross-feed list entry should trigger a fresh
-    /// network refresh or rely on the most recent cached snapshot.
-    static var lastRefreshCompletedAt: Date? {
-        let ts = UserDefaults.standard.double(forKey: lastRefreshCompletedKey)
-        return ts > 0 ? Date(timeIntervalSince1970: ts) : nil
-    }
-
     // MARK: - Dependencies
 
     private let persistence: FeedPersisting
@@ -47,6 +37,7 @@ final class FeedRefreshService {
     private let articleRetention: ArticleRetaining
     private let thumbnailService: ArticleThumbnailCaching
     private let networkMonitor: NetworkMonitoring
+    private let userDefaults: UserDefaults
 
     /// Background thumbnail prefetch task kicked off at the end of a refresh.
     /// Retained so `awaitPendingWork()` can drain it on behalf of a background
@@ -90,7 +81,8 @@ final class FeedRefreshService {
         thumbnailPrefetcher: ThumbnailPrefetching? = nil,
         articleRetention: ArticleRetaining = ArticleRetentionService(),
         thumbnailService: ArticleThumbnailCaching = ArticleThumbnailService(),
-        networkMonitor: NetworkMonitoring? = nil
+        networkMonitor: NetworkMonitoring? = nil,
+        userDefaults: UserDefaults = .standard
     ) {
         self.persistence = persistence
         self.feedFetching = feedFetching
@@ -103,6 +95,7 @@ final class FeedRefreshService {
         self.articleRetention = articleRetention
         self.thumbnailService = thumbnailService
         self.networkMonitor = resolvedMonitor
+        self.userDefaults = userDefaults
 
         // Observe the WiFi-only setting change notification so that toggling
         // the setting while a prefetch batch is in flight promptly cancels any
@@ -262,7 +255,7 @@ final class FeedRefreshService {
         // and `.cancelled` intentionally leave the timestamp alone so the
         // throttle doesn't swallow those paths on the next entry.
         if case .completed = outcome {
-            UserDefaults.standard.set(
+            userDefaults.set(
                 Date().timeIntervalSince1970,
                 forKey: Self.lastRefreshCompletedKey
             )

--- a/RSSApp/ViewModels/ArticleListSources.swift
+++ b/RSSApp/ViewModels/ArticleListSources.swift
@@ -153,8 +153,8 @@ final class AllArticlesSource: ArticleListSource {
         // so the user sees content even if the network is slow or offline.
         homeViewModel.loadAllArticles()
         // Throttled network refresh. `HomeViewModel.shouldRefreshOnEntry`
-        // reads the process-wide `FeedRefreshService.lastRefreshCompletedAt`
-        // timestamp and returns `false` when the most recent refresh is
+        // reads the last-refresh timestamp from the injected UserDefaults
+        // instance and returns `false` when the most recent refresh is
         // within `entryRefreshInterval` — so rapid navigation across sibling
         // cross-feed views (or a BG refresh that ran moments ago) doesn't
         // stack redundant refreshes on every entry. Pull-to-refresh goes

--- a/RSSApp/ViewModels/HomeViewModel.swift
+++ b/RSSApp/ViewModels/HomeViewModel.swift
@@ -15,25 +15,25 @@ final class HomeViewModel {
     /// Articles` in rapid succession should see cached data on the second
     /// entry rather than stacking redundant refreshes. Pull-to-refresh is
     /// never throttled — it's an explicit user action that bypasses the gate.
-    /// Background refresh updates the same timestamp via
-    /// `FeedRefreshService.lastRefreshCompletedAt`, so the throttle honors BG
-    /// work as well as foreground work.
+    /// Background refresh updates the same timestamp via the injected
+    /// `UserDefaults` instance (key: `FeedRefreshService.lastRefreshCompletedKey`),
+    /// so the throttle honors BG work as well as foreground work.
     static let entryRefreshInterval: TimeInterval = 5 * 60
 
     /// Whether a fresh on-entry network refresh should be triggered. Reads the
-    /// process-wide `FeedRefreshService.lastRefreshCompletedAt` timestamp
-    /// (shared with the BG refresh path) and compares it against
-    /// `entryRefreshInterval`. Returns `true` when no refresh has ever
-    /// completed on this install, or when the most recent completion is
-    /// older than the interval. Used by `AllArticlesSource`,
-    /// `UnreadArticlesSource`, and `GroupArticleSource` to gate the
-    /// `refreshAllFeeds()` call in their `initialLoad()`;
-    /// `SavedArticlesSource` does not consult it at all because saved
-    /// articles never benefit from a feed refresh.
+    /// last-refresh timestamp from the injected `UserDefaults` instance using
+    /// `FeedRefreshService.lastRefreshCompletedKey` (shared with the BG refresh
+    /// path) and compares it against `entryRefreshInterval`. Returns `true`
+    /// when no refresh has ever completed on this install, or when the most
+    /// recent completion is older than the interval. Used by
+    /// `AllArticlesSource`, `UnreadArticlesSource`, and `GroupArticleSource`
+    /// to gate the `refreshAllFeeds()` call in their `initialLoad()`;
+    /// `SavedArticlesSource` does not consult it at all because saved articles
+    /// never benefit from a feed refresh.
     var shouldRefreshOnEntry: Bool {
-        guard let last = FeedRefreshService.lastRefreshCompletedAt else {
-            return true
-        }
+        let ts = userDefaults.double(forKey: FeedRefreshService.lastRefreshCompletedKey)
+        guard ts > 0 else { return true }
+        let last = Date(timeIntervalSince1970: ts)
         return Date().timeIntervalSince(last) > Self.entryRefreshInterval
     }
 

--- a/RSSAppTests/ViewModels/ArticleListSourceTests.swift
+++ b/RSSAppTests/ViewModels/ArticleListSourceTests.swift
@@ -98,9 +98,10 @@ struct ArticleListSourceTests {
     @Test("AllArticlesSource.initialLoad triggers refresh closure on first entry")
     @MainActor
     func allArticlesSourceInitialLoadTriggersRefresh() async {
-        // Clear any ambient throttle timestamp from other tests so this
+        // Use an isolated UserDefaults suite with no throttle timestamp so this
         // asserts the "first entry" path unambiguously.
-        UserDefaults.standard.removeObject(forKey: FeedRefreshService.lastRefreshCompletedKey)
+        let defaults = UserDefaults(suiteName: "test.allArticles.initialLoad.triggers")!
+        defaults.removePersistentDomain(forName: "test.allArticles.initialLoad.triggers")
 
         let probe = RefreshProbe()
         let mockPersistence = MockFeedPersistenceService()
@@ -113,6 +114,7 @@ struct ArticleListSourceTests {
 
         let viewModel = HomeViewModel(
             persistence: mockPersistence,
+            userDefaults: defaults,
             refreshFeeds: {
                 await probe.recordCall()
                 return nil
@@ -129,7 +131,8 @@ struct ArticleListSourceTests {
     @Test("UnreadArticlesSource.initialLoad triggers refresh closure on first entry")
     @MainActor
     func unreadArticlesSourceInitialLoadTriggersRefresh() async {
-        UserDefaults.standard.removeObject(forKey: FeedRefreshService.lastRefreshCompletedKey)
+        let defaults = UserDefaults(suiteName: "test.unreadArticles.initialLoad.triggers")!
+        defaults.removePersistentDomain(forName: "test.unreadArticles.initialLoad.triggers")
 
         let probe = RefreshProbe()
         let mockPersistence = MockFeedPersistenceService()
@@ -142,6 +145,7 @@ struct ArticleListSourceTests {
 
         let viewModel = HomeViewModel(
             persistence: mockPersistence,
+            userDefaults: defaults,
             refreshFeeds: {
                 await probe.recordCall()
                 return nil
@@ -238,17 +242,17 @@ struct ArticleListSourceTests {
 
     /// Follow-up to cross-feed refresh: rapid navigation across sibling cross-feed lists (or
     /// re-entry within the throttle window) must NOT stack redundant network
-    /// refreshes. Seeds the shared `FeedRefreshService.lastRefreshCompletedKey`
-    /// UserDefaults entry to "just now" and then asserts `initialLoad()` does
-    /// not call the refresh closure.
+    /// refreshes. Seeds the injected UserDefaults suite with a "just now"
+    /// timestamp and then asserts `initialLoad()` does not call the refresh closure.
     @Test("AllArticlesSource.initialLoad skips refresh when within throttle window")
     @MainActor
     func allArticlesSourceInitialLoadThrottled() async {
-        UserDefaults.standard.set(
+        let defaults = UserDefaults(suiteName: "test.allArticles.initialLoad.throttled")!
+        defaults.removePersistentDomain(forName: "test.allArticles.initialLoad.throttled")
+        defaults.set(
             Date().timeIntervalSince1970,
             forKey: FeedRefreshService.lastRefreshCompletedKey
         )
-        defer { UserDefaults.standard.removeObject(forKey: FeedRefreshService.lastRefreshCompletedKey) }
 
         let probe = RefreshProbe()
         let mockPersistence = MockFeedPersistenceService()
@@ -260,6 +264,7 @@ struct ArticleListSourceTests {
 
         let viewModel = HomeViewModel(
             persistence: mockPersistence,
+            userDefaults: defaults,
             refreshFeeds: {
                 await probe.recordCall()
                 return nil
@@ -281,9 +286,10 @@ struct ArticleListSourceTests {
     @Test("AllArticlesSource.initialLoad refreshes when throttle window has elapsed")
     @MainActor
     func allArticlesSourceInitialLoadRefreshesWhenStale() async {
+        let defaults = UserDefaults(suiteName: "test.allArticles.initialLoad.stale")!
+        defaults.removePersistentDomain(forName: "test.allArticles.initialLoad.stale")
         let tenMinutesAgo = Date().addingTimeInterval(-600).timeIntervalSince1970
-        UserDefaults.standard.set(tenMinutesAgo, forKey: FeedRefreshService.lastRefreshCompletedKey)
-        defer { UserDefaults.standard.removeObject(forKey: FeedRefreshService.lastRefreshCompletedKey) }
+        defaults.set(tenMinutesAgo, forKey: FeedRefreshService.lastRefreshCompletedKey)
 
         let probe = RefreshProbe()
         let mockPersistence = MockFeedPersistenceService()
@@ -292,6 +298,7 @@ struct ArticleListSourceTests {
 
         let viewModel = HomeViewModel(
             persistence: mockPersistence,
+            userDefaults: defaults,
             refreshFeeds: {
                 await probe.recordCall()
                 return nil
@@ -312,8 +319,10 @@ struct ArticleListSourceTests {
     @Test("SavedArticlesSource.initialLoad never triggers network refresh")
     @MainActor
     func savedArticlesSourceInitialLoadNeverRefreshes() async {
-        // Clear any ambient throttle state so this is the unambiguous case.
-        UserDefaults.standard.removeObject(forKey: FeedRefreshService.lastRefreshCompletedKey)
+        // Use an isolated UserDefaults suite with no throttle state so this
+        // is the unambiguous case.
+        let defaults = UserDefaults(suiteName: "test.savedArticles.initialLoad.neverRefreshes")!
+        defaults.removePersistentDomain(forName: "test.savedArticles.initialLoad.neverRefreshes")
 
         let probe = RefreshProbe()
         let mockPersistence = MockFeedPersistenceService()
@@ -326,6 +335,7 @@ struct ArticleListSourceTests {
 
         let viewModel = HomeViewModel(
             persistence: mockPersistence,
+            userDefaults: defaults,
             refreshFeeds: {
                 await probe.recordCall()
                 return nil

--- a/RSSAppTests/ViewModels/HomeViewModelTests.swift
+++ b/RSSAppTests/ViewModels/HomeViewModelTests.swift
@@ -1077,35 +1077,38 @@ struct HomeViewModelTests {
     @Test("shouldRefreshOnEntry returns true when no refresh has ever completed")
     @MainActor
     func shouldRefreshOnEntryNeverRefreshed() {
-        UserDefaults.standard.removeObject(forKey: FeedRefreshService.lastRefreshCompletedKey)
-        let viewModel = HomeViewModel(persistence: MockFeedPersistenceService())
+        let defaults = UserDefaults(suiteName: "test.shouldRefreshOnEntry.neverRefreshed")!
+        defaults.removePersistentDomain(forName: "test.shouldRefreshOnEntry.neverRefreshed")
+        let viewModel = HomeViewModel(persistence: MockFeedPersistenceService(), userDefaults: defaults)
         #expect(viewModel.shouldRefreshOnEntry == true)
     }
 
     @Test("shouldRefreshOnEntry returns false when refresh is within throttle window")
     @MainActor
     func shouldRefreshOnEntryWithinWindow() {
-        UserDefaults.standard.set(
+        let defaults = UserDefaults(suiteName: "test.shouldRefreshOnEntry.withinWindow")!
+        defaults.removePersistentDomain(forName: "test.shouldRefreshOnEntry.withinWindow")
+        defaults.set(
             Date().timeIntervalSince1970,
             forKey: FeedRefreshService.lastRefreshCompletedKey
         )
-        defer { UserDefaults.standard.removeObject(forKey: FeedRefreshService.lastRefreshCompletedKey) }
 
-        let viewModel = HomeViewModel(persistence: MockFeedPersistenceService())
+        let viewModel = HomeViewModel(persistence: MockFeedPersistenceService(), userDefaults: defaults)
         #expect(viewModel.shouldRefreshOnEntry == false)
     }
 
     @Test("shouldRefreshOnEntry returns true when refresh is older than throttle window")
     @MainActor
     func shouldRefreshOnEntryOutsideWindow() {
+        let defaults = UserDefaults(suiteName: "test.shouldRefreshOnEntry.outsideWindow")!
+        defaults.removePersistentDomain(forName: "test.shouldRefreshOnEntry.outsideWindow")
         let sixMinutesAgo = Date().addingTimeInterval(-(6 * 60))
-        UserDefaults.standard.set(
+        defaults.set(
             sixMinutesAgo.timeIntervalSince1970,
             forKey: FeedRefreshService.lastRefreshCompletedKey
         )
-        defer { UserDefaults.standard.removeObject(forKey: FeedRefreshService.lastRefreshCompletedKey) }
 
-        let viewModel = HomeViewModel(persistence: MockFeedPersistenceService())
+        let viewModel = HomeViewModel(persistence: MockFeedPersistenceService(), userDefaults: defaults)
         #expect(viewModel.shouldRefreshOnEntry == true)
     }
 


### PR DESCRIPTION
## Summary
- `HomeViewModel.shouldRefreshOnEntry` previously read the last-refresh timestamp via `FeedRefreshService.lastRefreshCompletedAt` (a static that hard-coded `UserDefaults.standard`), bypassing the injected `UserDefaults` instance and causing cross-test state leakage
- `FeedRefreshService` now accepts a `userDefaults` parameter (defaulting to `.standard`) and uses it for both writing the completion timestamp and exposing the key for readers
- `HomeViewModel.shouldRefreshOnEntry` now reads directly from `self.userDefaults` using `FeedRefreshService.lastRefreshCompletedKey`, completing the isolation
- All `shouldRefreshOnEntry` and throttle tests in `HomeViewModelTests` and `ArticleListSourceTests` now use isolated `UserDefaults` suites instead of writing to `UserDefaults.standard`

Closes #422