### PR TITLE
fix: Skip backoff recording when icon resolution task is cancelled

### DIFF
--- a/RSSApp/Views/FeedIconView.swift
+++ b/RSSApp/Views/FeedIconView.swift
@@ -155,7 +155,10 @@ struct FeedIconView: View {
             // are not genuine resolution failures and should not suppress future
             // icon load attempts (e.g. during rapid scrolling, which triggers many
             // cancellations via .task(id:) teardown).
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled else {
+                Self.logger.debug("Skipping backoff recording for feed \(feedID.uuidString, privacy: .public) — caller task cancelled")
+                return
+            }
             ImageLoadBackoffTracker.feedIcons.recordFailure(for: backoffKey)
             iconImage = nil
             return

--- a/RSSApp/Views/FeedIconView.swift
+++ b/RSSApp/Views/FeedIconView.swift
@@ -151,6 +151,11 @@ struct FeedIconView: View {
         )
 
         guard let resolved else {
+            // Do not record a backoff failure for cancellation — cancelled tasks
+            // are not genuine resolution failures and should not suppress future
+            // icon load attempts (e.g. during rapid scrolling, which triggers many
+            // cancellations via .task(id:) teardown).
+            guard !Task.isCancelled else { return }
             ImageLoadBackoffTracker.feedIcons.recordFailure(for: backoffKey)
             iconImage = nil
             return


### PR DESCRIPTION
## Summary
- Prevents task cancellations (e.g. from rapid scroll-driven `.task(id:)` teardown) from being misrecorded as genuine icon resolution failures
- Without this guard, enough cancellations for a single feed could accumulate to hit the backoff threshold, erroneously suppressing all future icon load attempts for that feed

Closes #424

## Test plan
- [x] Built successfully for iOS 26
- [x] All existing tests pass