### PR TITLE
fix: Inject isolated UserDefaults into FeedRefreshServiceTests.makeService() (#426)

### DIFF
--- a/RSSAppTests/Services/FeedRefreshServiceTests.swift
+++ b/RSSAppTests/Services/FeedRefreshServiceTests.swift
@@ -17,7 +17,8 @@ struct FeedRefreshServiceTests {
         thumbnailPrefetcher: ThumbnailPrefetching? = nil,
         articleRetention: ArticleRetaining = MockArticleRetentionService(),
         thumbnailService: ArticleThumbnailCaching = MockArticleThumbnailService(),
-        networkMonitor: NetworkMonitoring = MockNetworkMonitorService()
+        networkMonitor: NetworkMonitoring = MockNetworkMonitorService(),
+        userDefaults: UserDefaults = UserDefaults(suiteName: "FeedRefreshServiceTests-\(UUID().uuidString)")!
     ) -> FeedRefreshService {
         FeedRefreshService(
             persistence: persistence,
@@ -26,7 +27,8 @@ struct FeedRefreshServiceTests {
             thumbnailPrefetcher: thumbnailPrefetcher ?? MockThumbnailPrefetchService(),
             articleRetention: articleRetention,
             thumbnailService: thumbnailService,
-            networkMonitor: networkMonitor
+            networkMonitor: networkMonitor,
+            userDefaults: userDefaults
         )
     }
 


### PR DESCRIPTION
## Summary
- Tests that produce a `.completed` outcome no longer write the last-refresh timestamp to `UserDefaults.standard`, eliminating cross-test state leakage that was the same pattern fixed in HomeViewModelTests by PR #425

## Changes
- Added `userDefaults:` parameter to `makeService(...)` in `FeedRefreshServiceTests.swift` with a per-invocation isolated suite (`FeedRefreshServiceTests-<UUID>`)
- Forwarded the parameter to `FeedRefreshService(userDefaults:)` in the factory

## Test plan
- [x] All 30 tests in `FeedRefreshServiceTests` pass

Fixes #426