### PR TITLE
refactor: Align FeedIconResolving.resolveAndCacheIcon with typed-throws pattern

### DIFF
--- a/RSSApp/Services/FeedIconService.swift
+++ b/RSSApp/Services/FeedIconService.swift
@@ -148,7 +148,7 @@ actor FeedIconResolutionCoordinator {
 
     // RATIONALE: The task stores a `Result` so cancellation and failure are structurally
     // distinct at the type level without requiring `Task<_, CancellationError>` typed-error
-    // tasks, which Swift 6.3 does not support in the unstructured `Task {}` initializer.
+    // tasks, which (as of Swift 6.3) the unstructured `Task {}` initializer does not support.
     // `.failure(CancellationError())` propagates via `get()` so all awaiting callers receive
     // the throw, while `.success(nil)` represents a genuine resolution failure (no icon found).
     private var inFlight: [UUID: Task<Result<(url: URL, backgroundStyle: FeedIconBackgroundStyle)?, CancellationError>, Never>] = [:]
@@ -182,7 +182,7 @@ actor FeedIconResolutionCoordinator {
         // RATIONALE: The inner `do/catch` is typed with `throws(CancellationError)` so the
         // compiler narrows `e` to `CancellationError` at the call site, avoiding an `as!`
         // cast. This works because `work` is declared `throws(CancellationError)` and the
-        // Swift 6.3 typed-throws rule guarantees the catch block only executes for that type.
+        // typed-throws rule (as of Swift 6.3) guarantees the catch block only executes for that type.
         let task = Task<Result<(url: URL, backgroundStyle: FeedIconBackgroundStyle)?, CancellationError>, Never> {
             do throws(CancellationError) {
                 return .success(try await work())

--- a/RSSApp/Services/FeedIconService.swift
+++ b/RSSApp/Services/FeedIconService.swift
@@ -79,7 +79,13 @@ protocol FeedIconResolving: Sendable {
     ///
     /// Returns the remote URL of the cached icon along with the luminance-based
     /// background-style classification, or `nil` when no candidate could be cached.
-    func resolveAndCacheIcon(feedSiteURL: URL?, feedImageURL: URL?, feedID: UUID) async -> (url: URL, backgroundStyle: FeedIconBackgroundStyle)?
+    ///
+    /// Throws `CancellationError` if the current task is cancelled during resolution.
+    /// The `throws(CancellationError)` typed-throws signature compile-time enforces that
+    /// no other error type can escape: all network, HTTP, decode, and filesystem
+    /// failures are surfaced via the `nil` return so callers can distinguish
+    /// cancellation (stop, no retry needed) from genuine failure (record backoff).
+    func resolveAndCacheIcon(feedSiteURL: URL?, feedImageURL: URL?, feedID: UUID) async throws(CancellationError) -> (url: URL, backgroundStyle: FeedIconBackgroundStyle)?
 
     /// Classifies the background style of an already-cached icon without
     /// touching the network. Used to back-fill `FeedIconBackgroundStyle` for
@@ -140,7 +146,12 @@ actor FeedIconResolutionCoordinator {
 
     private static let logger = Logger(category: "FeedIconResolutionCoordinator")
 
-    private var inFlight: [UUID: Task<(url: URL, backgroundStyle: FeedIconBackgroundStyle)?, Never>] = [:]
+    // RATIONALE: The task stores a `Result` so cancellation and failure are structurally
+    // distinct at the type level without requiring `Task<_, CancellationError>` typed-error
+    // tasks, which Swift 6.3 does not support in the unstructured `Task {}` initializer.
+    // `.failure(CancellationError())` propagates via `get()` so all awaiting callers receive
+    // the throw, while `.success(nil)` represents a genuine resolution failure (no icon found).
+    private var inFlight: [UUID: Task<Result<(url: URL, backgroundStyle: FeedIconBackgroundStyle)?, CancellationError>, Never>] = [:]
 
     /// If a resolution for `feedID` is already in progress, awaits and returns
     /// its result. Otherwise starts `work` and shares the result with all
@@ -154,24 +165,35 @@ actor FeedIconResolutionCoordinator {
     /// subsequent callers to enter `coalesce` and find the existing in-flight
     /// entry before the first task completes. Callers that arrive after the task
     /// finishes (and the entry is removed) start a fresh resolution.
+    ///
+    /// Throws `CancellationError` if the underlying work threw one, propagating
+    /// cancellation structurally to all callers awaiting the same in-flight task.
     func coalesce(
         feedID: UUID,
-        work: @Sendable @escaping () async -> (url: URL, backgroundStyle: FeedIconBackgroundStyle)?
-    ) async -> (url: URL, backgroundStyle: FeedIconBackgroundStyle)? {
+        work: @Sendable @escaping () async throws(CancellationError) -> (url: URL, backgroundStyle: FeedIconBackgroundStyle)?
+    ) async throws(CancellationError) -> (url: URL, backgroundStyle: FeedIconBackgroundStyle)? {
         if let existing = inFlight[feedID] {
             Self.logger.debug(
                 "Coalescing icon resolution for feed \(feedID.uuidString, privacy: .public) — awaiting in-flight task"
             )
-            return await existing.value
+            return try await existing.value.get()
         }
 
-        let task = Task<(url: URL, backgroundStyle: FeedIconBackgroundStyle)?, Never> {
-            await work()
+        // RATIONALE: The inner `do/catch` is typed with `throws(CancellationError)` so the
+        // compiler narrows `e` to `CancellationError` at the call site, avoiding an `as!`
+        // cast. This works because `work` is declared `throws(CancellationError)` and the
+        // Swift 6.3 typed-throws rule guarantees the catch block only executes for that type.
+        let task = Task<Result<(url: URL, backgroundStyle: FeedIconBackgroundStyle)?, CancellationError>, Never> {
+            do throws(CancellationError) {
+                return .success(try await work())
+            } catch {
+                return .failure(error)
+            }
         }
         inFlight[feedID] = task
-        let result = await task.value
+        let taskResult = await task.value
         inFlight.removeValue(forKey: feedID)
-        return result
+        return try taskResult.get()
     }
 }
 
@@ -279,9 +301,9 @@ struct FeedIconService: FeedIconResolving {
         }.value
     }
 
-    func resolveAndCacheIcon(feedSiteURL: URL?, feedImageURL: URL?, feedID: UUID) async -> (url: URL, backgroundStyle: FeedIconBackgroundStyle)? {
-        await resolutionCoordinator.coalesce(feedID: feedID) { [self] in
-            await self.performResolveAndCacheIcon(
+    func resolveAndCacheIcon(feedSiteURL: URL?, feedImageURL: URL?, feedID: UUID) async throws(CancellationError) -> (url: URL, backgroundStyle: FeedIconBackgroundStyle)? {
+        try await resolutionCoordinator.coalesce(feedID: feedID) { [self] () async throws(CancellationError) in
+            try await self.performResolveAndCacheIcon(
                 feedSiteURL: feedSiteURL,
                 feedImageURL: feedImageURL,
                 feedID: feedID
@@ -289,7 +311,7 @@ struct FeedIconService: FeedIconResolving {
         }
     }
 
-    private func performResolveAndCacheIcon(feedSiteURL: URL?, feedImageURL: URL?, feedID: UUID) async -> (url: URL, backgroundStyle: FeedIconBackgroundStyle)? {
+    private func performResolveAndCacheIcon(feedSiteURL: URL?, feedImageURL: URL?, feedID: UUID) async throws(CancellationError) -> (url: URL, backgroundStyle: FeedIconBackgroundStyle)? {
         Self.logger.debug("resolveAndCacheIcon() for feed \(feedID.uuidString, privacy: .public)")
 
         // Fetch site HTML to discover link icons
@@ -353,9 +375,9 @@ struct FeedIconService: FeedIconResolving {
         }
 
         guard !downloadedCandidates.isEmpty else {
-            guard !Task.isCancelled else {
+            if Task.isCancelled {
                 Self.logger.debug("Skipping miss recording for feed \(feedID.uuidString, privacy: .public) — task cancelled (no candidates downloaded)")
-                return nil
+                throw CancellationError()
             }
             let missCount = await missTracker.recordMiss(for: feedID)
             if missCount == FeedIconMissTracker.missThreshold {
@@ -410,9 +432,9 @@ struct FeedIconService: FeedIconResolving {
             }
         }
 
-        guard !Task.isCancelled else {
+        if Task.isCancelled {
             Self.logger.debug("Skipping miss recording for feed \(feedID.uuidString, privacy: .public) — task cancelled (all candidates failed)")
-            return nil
+            throw CancellationError()
         }
         let missCount = await missTracker.recordMiss(for: feedID)
         if missCount == FeedIconMissTracker.missThreshold {

--- a/RSSApp/Services/FeedRefreshService.swift
+++ b/RSSApp/Services/FeedRefreshService.swift
@@ -670,11 +670,17 @@ final class FeedRefreshService {
             }
             return
         }
-        let resolved = await feedIconService.resolveAndCacheIcon(
-            feedSiteURL: siteURL,
-            feedImageURL: feedImageURL,
-            feedID: feed.id
-        )
+        let resolved: (url: URL, backgroundStyle: FeedIconBackgroundStyle)?
+        do {
+            resolved = try await feedIconService.resolveAndCacheIcon(
+                feedSiteURL: siteURL,
+                feedImageURL: feedImageURL,
+                feedID: feed.id
+            )
+        } catch {
+            Self.logger.debug("Icon resolution cancelled for '\(feed.title, privacy: .public)'")
+            return
+        }
         if let resolved {
             do {
                 try persistence.applyIconResolution(resolved, to: feed)

--- a/RSSApp/ViewModels/AddFeedViewModel.swift
+++ b/RSSApp/ViewModels/AddFeedViewModel.swift
@@ -264,11 +264,17 @@ final class AddFeedViewModel {
         let feedImageURL = rssFeed.imageURL
         let persistenceRef = self.persistence
         Task {
-            let resolved = await iconService.resolveAndCacheIcon(
-                feedSiteURL: siteURL,
-                feedImageURL: feedImageURL,
-                feedID: newFeed.id
-            )
+            let resolved: (url: URL, backgroundStyle: FeedIconBackgroundStyle)?
+            do {
+                resolved = try await iconService.resolveAndCacheIcon(
+                    feedSiteURL: siteURL,
+                    feedImageURL: feedImageURL,
+                    feedID: newFeed.id
+                )
+            } catch {
+                Self.logger.debug("Icon resolution cancelled for '\(feedTitle, privacy: .public)'")
+                return
+            }
             guard resolved != nil else { return }
             do {
                 try persistenceRef.applyIconResolution(resolved, to: newFeed)

--- a/RSSApp/Views/FeedIconView.swift
+++ b/RSSApp/Views/FeedIconView.swift
@@ -144,21 +144,24 @@ struct FeedIconView: View {
             return
         }
 
-        let resolved = await iconService.resolveAndCacheIcon(
-            feedSiteURL: feedSiteURL,
-            feedImageURL: feedImageURL,
-            feedID: feedID
-        )
+        let resolved: (url: URL, backgroundStyle: FeedIconBackgroundStyle)?
+        do {
+            resolved = try await iconService.resolveAndCacheIcon(
+                feedSiteURL: feedSiteURL,
+                feedImageURL: feedImageURL,
+                feedID: feedID
+            )
+        } catch {
+            // CancellationError: do not record a backoff failure — cancelled tasks are not
+            // genuine resolution failures and should not suppress future icon load attempts
+            // (e.g. during rapid scrolling, which triggers many cancellations via .task(id:)
+            // teardown). The typed-throws signature structurally guarantees only CancellationError
+            // escapes here, eliminating the prior Task.isCancelled heuristic race.
+            Self.logger.debug("Skipping backoff recording for feed \(feedID.uuidString, privacy: .public) — resolution cancelled")
+            return
+        }
 
         guard let resolved else {
-            // Do not record a backoff failure for cancellation — cancelled tasks
-            // are not genuine resolution failures and should not suppress future
-            // icon load attempts (e.g. during rapid scrolling, which triggers many
-            // cancellations via .task(id:) teardown).
-            guard !Task.isCancelled else {
-                Self.logger.debug("Skipping backoff recording for feed \(feedID.uuidString, privacy: .public) — caller task cancelled")
-                return
-            }
             ImageLoadBackoffTracker.feedIcons.recordFailure(for: backoffKey)
             iconImage = nil
             return

--- a/RSSAppTests/Mocks/MockFeedIconService.swift
+++ b/RSSAppTests/Mocks/MockFeedIconService.swift
@@ -55,9 +55,17 @@ final class MockFeedIconService: FeedIconResolving, @unchecked Sendable {
         return loadValidatedIconResult
     }
 
-    func resolveAndCacheIcon(feedSiteURL: URL?, feedImageURL: URL?, feedID: UUID) async -> (url: URL, backgroundStyle: FeedIconBackgroundStyle)? {
+    /// When `simulateCancellation` is `true`, the mock throws `CancellationError`
+    /// instead of returning `resolveAndCacheResult`. Used to test that callers
+    /// handle the typed-throws cancellation path without recording backoff.
+    var simulateCancellation = false
+
+    func resolveAndCacheIcon(feedSiteURL: URL?, feedImageURL: URL?, feedID: UUID) async throws(CancellationError) -> (url: URL, backgroundStyle: FeedIconBackgroundStyle)? {
         resolveAndCacheCallCount += 1
         resolveAndCacheFeedIDs.append(feedID)
+        if simulateCancellation {
+            throw CancellationError()
+        }
         return resolveAndCacheResult
     }
 

--- a/RSSAppTests/Services/FeedIconResolutionCoordinatorTests.swift
+++ b/RSSAppTests/Services/FeedIconResolutionCoordinatorTests.swift
@@ -19,7 +19,7 @@ struct FeedIconResolutionCoordinatorTests {
     // MARK: - Tests
 
     @Test("Concurrent calls for the same feedID coalesce to a single work invocation")
-    func concurrentCallsForSameFeedIDCoalesce() async {
+    func concurrentCallsForSameFeedIDCoalesce() async throws {
         let coordinator = FeedIconResolutionCoordinator()
         let counter = CallCounter()
         let feedID = UUID()
@@ -29,10 +29,10 @@ struct FeedIconResolutionCoordinatorTests {
         // Launch 5 tasks simultaneously for the same feedID.
         // The work closure delays 50ms so all callers are guaranteed to arrive
         // before the first task completes, ensuring coalescing is exercised.
-        await withTaskGroup(of: Void.self) { group in
+        try await withThrowingTaskGroup(of: Void.self) { group in
             for _ in 0..<5 {
                 group.addTask {
-                    let result = await coordinator.coalesce(feedID: feedID) {
+                    let result = try await coordinator.coalesce(feedID: feedID) {
                         await counter.increment()
                         try? await Task.sleep(for: .milliseconds(50))
                         return (url: expectedURL, backgroundStyle: expectedStyle)
@@ -48,15 +48,15 @@ struct FeedIconResolutionCoordinatorTests {
     }
 
     @Test("Concurrent calls for different feedIDs proceed independently")
-    func concurrentCallsForDifferentFeedIDsProceedIndependently() async {
+    func concurrentCallsForDifferentFeedIDsProceedIndependently() async throws {
         let coordinator = FeedIconResolutionCoordinator()
         let counter = CallCounter()
         let feedIDs = [UUID(), UUID(), UUID()]
 
-        await withTaskGroup(of: Void.self) { group in
+        try await withThrowingTaskGroup(of: Void.self) { group in
             for feedID in feedIDs {
                 group.addTask {
-                    _ = await coordinator.coalesce(feedID: feedID) {
+                    _ = try await coordinator.coalesce(feedID: feedID) {
                         await counter.increment()
                         return nil
                     }
@@ -103,7 +103,7 @@ struct FeedIconResolutionCoordinatorTests {
         // Task A: first caller — owns the work closure. Signals the gate when it
         // starts so we can cancel task B while the work is still in progress.
         let taskA = Task {
-            await coordinator.coalesce(feedID: feedID) {
+            try? await coordinator.coalesce(feedID: feedID) {
                 await counter.increment()
                 await gate.signal()
                 try? await Task.sleep(for: .milliseconds(100))
@@ -118,7 +118,7 @@ struct FeedIconResolutionCoordinatorTests {
         // It awaits the shared task; cancelling it must not cancel the coordinator's
         // unstructured Task, which is not a child of task B.
         let taskB = Task {
-            await coordinator.coalesce(feedID: feedID) {
+            try? await coordinator.coalesce(feedID: feedID) {
                 // This closure must never run — task B awaits task A's result.
                 await counter.increment()
                 return nil
@@ -128,7 +128,7 @@ struct FeedIconResolutionCoordinatorTests {
 
         // Task C: another concurrent caller that must still receive the correct result.
         let taskC = Task {
-            await coordinator.coalesce(feedID: feedID) {
+            try? await coordinator.coalesce(feedID: feedID) {
                 await counter.increment()
                 return nil
             }
@@ -145,19 +145,19 @@ struct FeedIconResolutionCoordinatorTests {
     }
 
     @Test("Completed entry is removed, allowing a fresh resolution on the next call")
-    func completedEntryRemovedAllowsFreshResolution() async {
+    func completedEntryRemovedAllowsFreshResolution() async throws {
         let coordinator = FeedIconResolutionCoordinator()
         let counter = CallCounter()
         let feedID = UUID()
 
         // First call — completes normally.
-        _ = await coordinator.coalesce(feedID: feedID) {
+        _ = try await coordinator.coalesce(feedID: feedID) {
             await counter.increment()
             return nil
         }
 
         // Second call — must start fresh because the first entry was removed on completion.
-        _ = await coordinator.coalesce(feedID: feedID) {
+        _ = try await coordinator.coalesce(feedID: feedID) {
             await counter.increment()
             return nil
         }

--- a/RSSAppTests/Services/FeedIconResolutionCoordinatorTests.swift
+++ b/RSSAppTests/Services/FeedIconResolutionCoordinatorTests.swift
@@ -90,7 +90,7 @@ struct FeedIconResolutionCoordinatorTests {
     }
 
     @Test("Cancelling one awaiter does not cancel the shared task or other awaiters")
-    func cancellingOneAwaiterDoesNotCancelSharedTask() async {
+    func cancellingOneAwaiterDoesNotCancelSharedTask() async throws {
         let coordinator = FeedIconResolutionCoordinator()
         let counter = CallCounter()
         let feedID = UUID()
@@ -102,8 +102,9 @@ struct FeedIconResolutionCoordinatorTests {
 
         // Task A: first caller — owns the work closure. Signals the gate when it
         // starts so we can cancel task B while the work is still in progress.
+        // `try` (not `try?`) so an unexpected throw fails the test loudly.
         let taskA = Task {
-            try? await coordinator.coalesce(feedID: feedID) {
+            try await coordinator.coalesce(feedID: feedID) {
                 await counter.increment()
                 await gate.signal()
                 try? await Task.sleep(for: .milliseconds(100))
@@ -127,21 +128,101 @@ struct FeedIconResolutionCoordinatorTests {
         taskB.cancel()
 
         // Task C: another concurrent caller that must still receive the correct result.
+        // `try` (not `try?`) so an unexpected throw fails the test loudly.
         let taskC = Task {
-            try? await coordinator.coalesce(feedID: feedID) {
+            try await coordinator.coalesce(feedID: feedID) {
                 await counter.increment()
                 return nil
             }
         }
 
-        let resultA = await taskA.value
+        let resultA = try await taskA.value
         _ = await taskB.value
-        let resultC = await taskC.value
+        let resultC = try await taskC.value
 
         let invokeCount = await counter.count
         #expect(invokeCount == 1, "Work closure should run exactly once; ran \(invokeCount) times")
         #expect(resultA?.url == expectedURL, "Task A should receive the resolved URL")
         #expect(resultC?.url == expectedURL, "Task C should receive the resolved URL despite task B being cancelled")
+    }
+
+    @Test("CancellationError from work propagates to all coalesced awaiters via Result")
+    func cancellationErrorPropagatesFromWorkToAllAwaiters() async {
+        let coordinator = FeedIconResolutionCoordinator()
+        let feedID = UUID()
+
+        // Gate ensures tasks B and C are coalesced on the same in-flight task
+        // before work completes and throws CancellationError.
+        let gate = Gate()
+
+        // Thread-safe store recording whether each task received CancellationError.
+        actor OutcomeStore {
+            private(set) var results: [Int: Bool] = [:]
+            func record(index: Int, threw: Bool) { results[index] = threw }
+        }
+        let outcomes = OutcomeStore()
+
+        // WorkProvider exposes the typed-throwing work as an actor method. The explicit
+        // closure signature on the `coalesce` call site below (`() async throws(CancellationError) ->`)
+        // is required because Swift cannot infer `throws(CancellationError)` for an
+        // `@Sendable` closure that calls an actor method — it widens to `any Error`.
+        actor WorkProvider {
+            let gate: Gate
+            init(gate: Gate) { self.gate = gate }
+
+            func cancellingWork() async throws(CancellationError) -> (url: URL, backgroundStyle: FeedIconBackgroundStyle)? {
+                await gate.signal()
+                // Pause so tasks B and C arrive and coalesce before work throws.
+                await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+                    DispatchQueue.global().asyncAfter(deadline: .now() + 0.05) { cont.resume() }
+                }
+                throw CancellationError()
+            }
+        }
+        let provider = WorkProvider(gate: gate)
+
+        // Three tasks coalesce on the same feedID. The work (owned by task A) throws
+        // CancellationError; all three callers must propagate that error — not return nil,
+        // which would incorrectly trigger backoff for a genuine resolution miss.
+        let taskA = Task<Void, Never> {
+            do {
+                _ = try await coordinator.coalesce(feedID: feedID) { () async throws(CancellationError) -> (url: URL, backgroundStyle: FeedIconBackgroundStyle)? in
+                    try await provider.cancellingWork()
+                }
+                await outcomes.record(index: 0, threw: false)
+            } catch {
+                await outcomes.record(index: 0, threw: error is CancellationError)
+            }
+        }
+
+        await gate.wait()
+
+        let taskB = Task<Void, Never> {
+            do {
+                _ = try await coordinator.coalesce(feedID: feedID) { nil }
+                await outcomes.record(index: 1, threw: false)
+            } catch {
+                await outcomes.record(index: 1, threw: error is CancellationError)
+            }
+        }
+
+        let taskC = Task<Void, Never> {
+            do {
+                _ = try await coordinator.coalesce(feedID: feedID) { nil }
+                await outcomes.record(index: 2, threw: false)
+            } catch {
+                await outcomes.record(index: 2, threw: error is CancellationError)
+            }
+        }
+
+        _ = await taskA.value
+        _ = await taskB.value
+        _ = await taskC.value
+
+        let results = await outcomes.results
+        #expect(results[0] == true, "Task A (work owner) should receive CancellationError")
+        #expect(results[1] == true, "Task B (coalesced awaiter) should receive CancellationError, not nil")
+        #expect(results[2] == true, "Task C (coalesced awaiter) should receive CancellationError, not nil")
     }
 
     @Test("Completed entry is removed, allowing a fresh resolution on the next call")

--- a/RSSAppTests/Services/FeedIconServiceTests.swift
+++ b/RSSAppTests/Services/FeedIconServiceTests.swift
@@ -647,14 +647,14 @@ struct FeedIconServiceTests {
     // MARK: - resolveAndCacheIcon miss-tracker integration
 
     @Test("resolveAndCacheIcon records exactly one miss when all candidates fail")
-    func resolveAndCacheIconRecordsOneMissWhenAllCandidatesFail() async {
+    func resolveAndCacheIconRecordsOneMissWhenAllCandidatesFail() async throws {
         let tracker = FeedIconMissTracker()
         let isolatedService = FeedIconService(cacheDirectoryOverride: cacheDirectory, missTracker: tracker)
         let feedID = UUID()
         // Use a URL under a reserved TLD — guaranteed to fail DNS resolution without touching the network.
         let siteURL = URL(string: "https://example-invalid-no-icon.invalid")!
 
-        _ = await isolatedService.resolveAndCacheIcon(feedSiteURL: siteURL, feedImageURL: nil, feedID: feedID)
+        _ = try await isolatedService.resolveAndCacheIcon(feedSiteURL: siteURL, feedImageURL: nil, feedID: feedID)
 
         // After one resolveAndCacheIcon call with all candidates failing, the tracker
         // should have recorded exactly 1 miss. Calling recordMiss again should return 2.


### PR DESCRIPTION
## Summary
- `resolveAndCacheIcon` now uses `throws(CancellationError)` so cancellation is structurally distinct from genuine failure at the protocol level — eliminates the need for `Task.isCancelled` heuristics to distinguish the two
- Fixes a race condition in `FeedIconView.loadIcon()` where a genuine `nil` result could be silently dropped if the SwiftUI `.task(id:)` was concurrently cancelled

## Changes
- `FeedIconResolving.resolveAndCacheIcon`: changed from `async -> (url: URL, backgroundStyle: FeedIconBackgroundStyle)?` to `async throws(CancellationError) -> ...?`
- `FeedIconResolutionCoordinator.coalesce`: changed to `throws(CancellationError)` using a `Result<..., CancellationError>` task payload (Swift 6.3 unstructured `Task {}` initializer doesn't support typed-error inference without a typed `do throws(...) {}` block)
- `FeedIconService.performResolveAndCacheIcon`: changed to `throws(CancellationError)` — the two `Task.isCancelled` checks now `throw CancellationError()` instead of `return nil`
- `FeedIconView.loadIcon()`: replaced `Task.isCancelled` heuristic with `do/catch` on the typed-throws call — the `catch` arm is the only path where backoff recording is skipped, making the distinction structural and race-free
- `FeedRefreshService.resolveAndCacheIconIfNeeded` + `AddFeedViewModel`: updated callers to `try await`
- `MockFeedIconService`: updated to `throws(CancellationError)` and added `simulateCancellation` flag
- `FeedIconResolutionCoordinatorTests` + `FeedIconServiceTests`: updated callers to `try await`

## Test plan
- [x] Built successfully for iOS 26 Simulator
- [x] All existing tests pass

Fixes #428