### PR TITLE
fix: FeedIconResolutionCoordinator.coalesce() checks cancellation after awaiting shared task (#431)

### DIFF
--- a/RSSApp/Services/FeedIconService.swift
+++ b/RSSApp/Services/FeedIconService.swift
@@ -176,7 +176,9 @@ actor FeedIconResolutionCoordinator {
             Self.logger.debug(
                 "Coalescing icon resolution for feed \(feedID.uuidString, privacy: .public) — awaiting in-flight task"
             )
-            return try await existing.value.get()
+            let result = try await existing.value.get()
+            if Task.isCancelled { throw CancellationError() }
+            return result
         }
 
         // RATIONALE: The inner `do/catch` is typed with `throws(CancellationError)` so the
@@ -193,6 +195,7 @@ actor FeedIconResolutionCoordinator {
         inFlight[feedID] = task
         let taskResult = await task.value
         inFlight.removeValue(forKey: feedID)
+        if Task.isCancelled { throw CancellationError() }
         return try taskResult.get()
     }
 }

--- a/RSSApp/Services/FeedIconService.swift
+++ b/RSSApp/Services/FeedIconService.swift
@@ -166,8 +166,9 @@ actor FeedIconResolutionCoordinator {
     /// entry before the first task completes. Callers that arrive after the task
     /// finishes (and the entry is removed) start a fresh resolution.
     ///
-    /// Throws `CancellationError` if the underlying work threw one, propagating
-    /// cancellation structurally to all callers awaiting the same in-flight task.
+    /// Throws `CancellationError` if the underlying work threw one (propagating
+    /// cancellation to all callers awaiting the same in-flight task), or if the
+    /// calling task itself was cancelled during the await.
     func coalesce(
         feedID: UUID,
         work: @Sendable @escaping () async throws(CancellationError) -> (url: URL, backgroundStyle: FeedIconBackgroundStyle)?

--- a/RSSAppTests/Services/FeedIconResolutionCoordinatorTests.swift
+++ b/RSSAppTests/Services/FeedIconResolutionCoordinatorTests.swift
@@ -225,6 +225,95 @@ struct FeedIconResolutionCoordinatorTests {
         #expect(results[2] == true, "Task C (coalesced awaiter) should receive CancellationError, not nil")
     }
 
+    @Test("Cancelled coalesced awaiter throws CancellationError instead of returning resolved value")
+    func cancelledCoalescedAwaiterThrowsCancellationError() async throws {
+        let coordinator = FeedIconResolutionCoordinator()
+        let feedID = UUID()
+        let expectedURL = URL(string: "https://example.com/icon.png")!
+        let expectedStyle = FeedIconBackgroundStyle.light
+
+        // Gate: let the test cancel task B only after the shared task is in flight.
+        let gate = Gate()
+
+        // Task A owns the work, signals the gate, then completes normally.
+        let taskA = Task {
+            try await coordinator.coalesce(feedID: feedID) {
+                await gate.signal()
+                try? await Task.sleep(for: .milliseconds(100))
+                return (url: expectedURL, backgroundStyle: expectedStyle)
+            }
+        }
+
+        // Wait until the work is running so task B will coalesce (not start fresh).
+        await gate.wait()
+
+        // Task B: coalesced caller — cancelled before the shared task finishes.
+        // After the fix, returning from `await existing.value.get()` must trigger
+        // `Task.checkCancellation()`, surfacing CancellationError to the caller.
+        actor OutcomeStore {
+            private(set) var threwCancellation = false
+            func record(_ threw: Bool) { threwCancellation = threw }
+        }
+        let outcome = OutcomeStore()
+        let taskB = Task<Void, Never> {
+            do {
+                _ = try await coordinator.coalesce(feedID: feedID) { nil }
+                await outcome.record(false)
+            } catch {
+                await outcome.record(error is CancellationError)
+            }
+        }
+        taskB.cancel()
+
+        _ = try await taskA.value
+        _ = await taskB.value
+
+        let threwCancellation = await outcome.threwCancellation
+        #expect(threwCancellation, "A cancelled coalesced awaiter should throw CancellationError, not return the resolved value")
+    }
+
+    @Test("Cancelled work-owning caller throws CancellationError instead of returning resolved value")
+    func cancelledWorkOwnerThrowsCancellationError() async throws {
+        let coordinator = FeedIconResolutionCoordinator()
+        let feedID = UUID()
+        let expectedURL = URL(string: "https://example.com/icon.png")!
+        let expectedStyle = FeedIconBackgroundStyle.light
+
+        // Gate: signals once the work closure has started, so we can cancel the
+        // work-owning task while it is still suspended at `await task.value`.
+        let gate = Gate()
+
+        actor OutcomeStore {
+            private(set) var threwCancellation = false
+            func record(_ threw: Bool) { threwCancellation = threw }
+        }
+        let outcome = OutcomeStore()
+
+        // Task A is the sole caller (work-owning path). It is cancelled mid-work.
+        // After the fix, `Task.checkCancellation()` after `await task.value` must
+        // surface CancellationError to task A even though the inner unstructured
+        // Task completed successfully.
+        let taskA = Task<Void, Never> {
+            do {
+                _ = try await coordinator.coalesce(feedID: feedID) {
+                    await gate.signal()
+                    try? await Task.sleep(for: .milliseconds(100))
+                    return (url: expectedURL, backgroundStyle: expectedStyle)
+                }
+                await outcome.record(false)
+            } catch {
+                await outcome.record(error is CancellationError)
+            }
+        }
+
+        await gate.wait()
+        taskA.cancel()
+        _ = await taskA.value
+
+        let threwCancellation = await outcome.threwCancellation
+        #expect(threwCancellation, "A cancelled work-owning caller should throw CancellationError after the shared task completes")
+    }
+
     @Test("Completed entry is removed, allowing a fresh resolution on the next call")
     func completedEntryRemovedAllowsFreshResolution() async throws {
         let coordinator = FeedIconResolutionCoordinator()


### PR DESCRIPTION
## Summary
- Cancelled callers suspended at `await existing.value.get()` (coalesced path) or `await task.value` (work-owning path) now throw `CancellationError` instead of returning the resolved value.
- This prevents inadvertently triggering backoff recording in `FeedIconView.loadIcon()` for tasks that were cancelled — a regression risk introduced by the typed-throws separation in PR #430.

Fixes #431

## Changes
- `RSSApp/Services/FeedIconService.swift`: Add `if Task.isCancelled { throw CancellationError() }` after each of the two awaits in `FeedIconResolutionCoordinator.coalesce()`.
- `RSSAppTests/Services/FeedIconResolutionCoordinatorTests.swift`: Add two new tests verifying the corrected cancellation behavior for both paths.

## Test plan
- [x] `cancelledCoalescedAwaiterThrowsCancellationError` — passes
- [x] `cancelledWorkOwnerThrowsCancellationError` — passes
- [x] All 7 `FeedIconResolutionCoordinatorTests` pass
- [x] Build succeeds for iOS 26 simulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)