### PR TITLE
fix: Downgrade expected icon resolution log messages from .warning to .info (#433)

### DIFF
--- a/RSSApp/Services/FeedIconService.swift
+++ b/RSSApp/Services/FeedIconService.swift
@@ -288,12 +288,12 @@ struct FeedIconService: FeedIconResolving {
         }
         return await Task.detached(priority: .userInitiated) { () -> UIImage? in
             guard let image = UIImage(contentsOfFile: fileURL.path(percentEncoded: false)) else {
-                Self.logger.warning("Cached icon file unreadable for feed \(feedID.uuidString, privacy: .public) at \(fileURL.path, privacy: .public) — deleting")
+                Self.logger.info("Cached icon file unreadable for feed \(feedID.uuidString, privacy: .public) at \(fileURL.path, privacy: .public) — deleting")
                 self.deleteCachedIcon(for: feedID)
                 return nil
             }
             guard Self.hasVisibleContent(image) else {
-                Self.logger.warning("Cached icon for feed \(feedID.uuidString, privacy: .public) has no visible content — deleting")
+                Self.logger.info("Cached icon for feed \(feedID.uuidString, privacy: .public) has no visible content — deleting")
                 self.deleteCachedIcon(for: feedID)
                 return nil
             }
@@ -1032,19 +1032,19 @@ struct FeedIconService: FeedIconResolving {
             guard let httpResponse = response as? HTTPURLResponse,
                   (200...299).contains(httpResponse.statusCode) else {
                 let code = (response as? HTTPURLResponse)?.statusCode ?? -1
-                Self.logger.warning("downloadAndAnalyze: HTTP \(code, privacy: .public) for \(url.absoluteString, privacy: .public)")
+                Self.logger.info("downloadAndAnalyze: HTTP \(code, privacy: .public) for \(url.absoluteString, privacy: .public)")
                 return nil
             }
 
             guard let image = UIImage(data: data) ?? Self.decodeICO(data) else {
-                Self.logger.warning("downloadAndAnalyze: not a valid image from \(url.absoluteString, privacy: .public)")
+                Self.logger.info("downloadAndAnalyze: not a valid image from \(url.absoluteString, privacy: .public)")
                 return nil
             }
 
             let normalized = normalizeImage(image)
             let stats = Self.analyzeIconPixels(normalized, feedID: feedID)
             guard stats.isVisible else {
-                Self.logger.warning("downloadAndAnalyze: image has no visible content from \(url.absoluteString, privacy: .public)")
+                Self.logger.info("downloadAndAnalyze: image has no visible content from \(url.absoluteString, privacy: .public)")
                 return nil
             }
 
@@ -1056,7 +1056,7 @@ struct FeedIconService: FeedIconResolving {
             Self.logger.debug("downloadAndAnalyze: download cancelled for \(url.absoluteString, privacy: .public)")
             return nil
         } catch {
-            Self.logger.warning("downloadAndAnalyze: download failed for \(url.absoluteString, privacy: .public): \(error, privacy: .public)")
+            Self.logger.info("downloadAndAnalyze: download failed for \(url.absoluteString, privacy: .public): \(error, privacy: .public)")
             return nil
         }
     }

--- a/RSSApp/Views/FeedIconView.swift
+++ b/RSSApp/Views/FeedIconView.swift
@@ -172,7 +172,7 @@ struct FeedIconView: View {
         Self.logger.notice("Resolved icon on-view for feed \(feedID.uuidString, privacy: .public)")
         let validated = await iconService.loadValidatedIcon(for: feedID)
         if validated == nil {
-            Self.logger.warning("Icon resolved for feed \(feedID.uuidString, privacy: .public) but failed post-cache validation")
+            Self.logger.info("Icon resolved for feed \(feedID.uuidString, privacy: .public) but failed post-cache validation")
         }
         iconImage = validated
 


### PR DESCRIPTION
## Summary
- Routine icon resolution failures (HTTP errors, non-image data, blank images, unreadable cache files) no longer appear as Error-level entries in Console.app, reducing noise that obscures genuine failures
- The icon resolution pipeline tries multiple candidate URLs by design; per-candidate failures are expected outcomes, not unexpected recoverable situations

Fixes #433

## Changes
- `FeedIconService.swift`: downgrade 6 `.warning` calls to `.info` in `loadValidatedIcon(for:)` and `downloadAndAnalyze(_:feedID:)` — HTTP non-2xx, non-image data, blank images, unreadable cache, blank cache, and network errors
- `FeedIconView.swift`: downgrade 1 `.warning` call to `.info` in `loadIcon()` — post-cache validation failure after successful resolution
- The 3 logs flagged as "do not change" (`writeNormalizedIcon: failed to write cache`, `analyzeIconPixels: image has no CGImage backing`, `analyzeIconPixels: CGContext creation failed`) remain at their existing levels

## Test plan
- [x] Built successfully for iOS 26
- [x] All existing tests pass