### PR TITLE
fix: Add defaults injection to AIProvider.active, aligning it with setActive

### DIFF
--- a/RSSApp/Models/AIProvider.swift
+++ b/RSSApp/Models/AIProvider.swift
@@ -101,8 +101,8 @@ enum AIProvider: String, CaseIterable, Sendable {
 
     /// The currently selected AI provider. Defaults to `.claude` when unset, matching
     /// the pre-multi-provider behavior so existing users are not disrupted on upgrade.
-    static var active: AIProvider {
-        guard let raw = UserDefaults.standard.string(forKey: activeProviderKey),
+    static func active(defaults: UserDefaults = .standard) -> AIProvider {
+        guard let raw = defaults.string(forKey: activeProviderKey),
               let provider = AIProvider(rawValue: raw) else {
             return .claude
         }

--- a/RSSApp/Services/KeychainService.swift
+++ b/RSSApp/Services/KeychainService.swift
@@ -140,7 +140,7 @@ extension KeychainServicing {
 
     /// Whether the currently active provider has a non-empty API key stored.
     func hasActiveAPIKey() throws -> Bool {
-        try hasAPIKey(for: AIProvider.active)
+        try hasAPIKey(for: AIProvider.active())
     }
 
     // MARK: Legacy single-provider methods (Claude / Anthropic)

--- a/RSSApp/ViewModels/DiscussionViewModel.swift
+++ b/RSSApp/ViewModels/DiscussionViewModel.swift
@@ -49,7 +49,7 @@ final class DiscussionViewModel {
         let input = currentInput.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !input.isEmpty, !isGenerating else { return }
 
-        let provider = AIProvider.active
+        let provider = AIProvider.active()
         let apiKey: String
         do {
             guard let key = try keychainService.loadAPIKey(for: provider), !key.isEmpty else {

--- a/RSSApp/Views/AISettingsView.swift
+++ b/RSSApp/Views/AISettingsView.swift
@@ -7,7 +7,7 @@ struct AISettingsView: View {
 
     // MARK: - State
 
-    @State private var selectedProvider: AIProvider = AIProvider.active
+    @State private var selectedProvider: AIProvider = AIProvider.active()
     @State private var keyInputs: [AIProvider: String] = [:]
     @State private var keyPresence: [AIProvider: Bool] = [:]
     @State private var modelInputs: [AIProvider: String] = [:]
@@ -271,7 +271,7 @@ struct AISettingsView: View {
     // MARK: - Load state
 
     private func loadAllState() {
-        selectedProvider = AIProvider.active
+        selectedProvider = AIProvider.active()
         loadError = nil
 
         for provider in AIProvider.allCases {

--- a/RSSAppTests/Models/AIProviderTests.swift
+++ b/RSSAppTests/Models/AIProviderTests.swift
@@ -59,33 +59,24 @@ struct AIProviderTests {
 
     @Test("active defaults to .claude when no value stored")
     func activeDefaultsClaude() {
-        // Standard defaults has no value set for this test, so we rely on
-        // AIProvider.active falling back when the rawValue is absent.
-        // We use a fresh defaults suite to avoid cross-test contamination.
         let defaults = makeTestDefaults()
-        // No value written — reading active should return .claude
-        let raw = defaults.string(forKey: "active_ai_provider")
-        #expect(raw == nil)
-        // Verify the static property falls back correctly (reads from standard)
-        // by checking the rawValue-based init:
-        #expect(AIProvider(rawValue: "") == nil)
-        // This confirms the nil-guard in active returns .claude
+        #expect(AIProvider.active(defaults: defaults) == .claude)
     }
 
-    @Test("setActive persists provider to UserDefaults")
+    @Test("setActive persists provider readable by active")
     func setActivePersists() {
         let defaults = makeTestDefaults()
         AIProvider.setActive(.gemini, defaults: defaults)
         #expect(defaults.string(forKey: "active_ai_provider") == "gemini")
+        #expect(AIProvider.active(defaults: defaults) == .gemini)
     }
 
-    @Test("setActive can round-trip all providers")
-    func setActiveRoundTrip() {
+    @Test("active round-trips all providers through setActive")
+    func activeRoundTrip() {
         let defaults = makeTestDefaults()
         for provider in AIProvider.allCases {
             AIProvider.setActive(provider, defaults: defaults)
-            let stored = defaults.string(forKey: "active_ai_provider")
-            #expect(AIProvider(rawValue: stored ?? "") == provider)
+            #expect(AIProvider.active(defaults: defaults) == provider)
         }
     }
 

--- a/RSSAppTests/ViewModels/DiscussionViewModelTests.swift
+++ b/RSSAppTests/ViewModels/DiscussionViewModelTests.swift
@@ -48,7 +48,7 @@ struct DiscussionViewModelTests {
 
     /// Saves and returns the current active provider so tests can restore it after
     /// mutating `AIProvider.active`. Use with `defer { AIProvider.setActive(saved) }`.
-    private func saveActiveProvider() -> AIProvider { AIProvider.active }
+    private func saveActiveProvider() -> AIProvider { AIProvider.active() }
 
     @Test("hasAPIKey reflects keychain state")
     func hasAPIKey() {

--- a/RSSAppTests/ViewModels/DiscussionViewModelTests.swift
+++ b/RSSAppTests/ViewModels/DiscussionViewModelTests.swift
@@ -17,7 +17,7 @@ struct DiscussionViewModelTests {
 
     /// Creates a `DiscussionViewModel` with a mock AI service and mock Keychain.
     ///
-    /// Callers are responsible for setting `AIProvider.active` before calling this
+    /// Callers are responsible for calling `AIProvider.setActive(_:)` before calling this
     /// helper and restoring it afterward via `defer { AIProvider.setActive(previous) }`.
     private func makeVM(
         chunks: [String] = ["Hello", " world"],
@@ -47,7 +47,7 @@ struct DiscussionViewModelTests {
     }
 
     /// Saves and returns the current active provider so tests can restore it after
-    /// mutating `AIProvider.active`. Use with `defer { AIProvider.setActive(saved) }`.
+    /// mutating it via `AIProvider.setActive(_:)`. Use with `defer { AIProvider.setActive(saved) }`.
     private func saveActiveProvider() -> AIProvider { AIProvider.active() }
 
     @Test("hasAPIKey reflects keychain state")


### PR DESCRIPTION
## Summary
- Fixes asymmetry where `AIProvider.active` always read from `UserDefaults.standard` while `setActive(_:defaults:)` accepted an injected `defaults` parameter, making isolated round-trip testing impossible
- Converts `static var active: AIProvider` to `static func active(defaults: UserDefaults = .standard) -> AIProvider`, matching the pattern of `currentModel(defaults:)` and `currentMaxTokens(defaults:)`

Closes #436

## Changes
- `RSSApp/Models/AIProvider.swift` — convert `active` from a computed property to a function with injectable `defaults` parameter
- `RSSApp/Services/KeychainService.swift`, `RSSApp/ViewModels/DiscussionViewModel.swift`, `RSSApp/Views/AISettingsView.swift` — update call sites to `AIProvider.active()`
- `RSSAppTests/Models/AIProviderTests.swift` — replace indirect workaround tests with direct isolated-defaults round-trip tests using `AIProvider.active(defaults:)`
- `RSSAppTests/ViewModels/DiscussionViewModelTests.swift` — update `saveActiveProvider()` helper to call `AIProvider.active()`

## Test plan
- [x] Full test suite passes (`xcodebuild test` succeeded)
- [x] `active(defaults:)` returns `.claude` when no value stored (isolated defaults)
- [x] `active(defaults:)` round-trips all providers written by `setActive(_:defaults:)` using isolated defaults