### PR TITLE
fix: Add URLSession injection to GeminiModelService for unit testing (#437)

### DIFF
--- a/RSSApp/Services/GeminiModelService.swift
+++ b/RSSApp/Services/GeminiModelService.swift
@@ -1,6 +1,16 @@
 import Foundation
 import os
 
+// MARK: - URLSessionDataProviding
+
+/// Abstracts URLSession's `data(for:)` so services like `GeminiModelService`
+/// can be tested with controlled response payloads without hitting the network.
+protocol URLSessionDataProviding: Sendable {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: URLSessionDataProviding {}
+
 // MARK: - GeminiModel
 
 struct GeminiModel: Sendable, Identifiable, Hashable {
@@ -23,6 +33,12 @@ struct GeminiModelService: GeminiModelFetching {
     private static let logger = Logger(category: "GeminiModelService")
     private static let listURL = "https://generativelanguage.googleapis.com/v1beta/models"
 
+    private let session: any URLSessionDataProviding
+
+    init(session: any URLSessionDataProviding = URLSession.shared) {
+        self.session = session
+    }
+
     /// Fetches the list of Gemini models that support `generateContent`.
     ///
     /// Strips the `models/` prefix from each name so the returned `id` values are
@@ -38,7 +54,7 @@ struct GeminiModelService: GeminiModelFetching {
         request.setValue(apiKey, forHTTPHeaderField: "x-goog-api-key")
         request.setValue("application/json", forHTTPHeaderField: "accept")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await session.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw AIServiceError.httpError(statusCode: 0)
         }

--- a/RSSAppTests/Mocks/MockURLSessionDataProvider.swift
+++ b/RSSAppTests/Mocks/MockURLSessionDataProvider.swift
@@ -1,0 +1,121 @@
+import Foundation
+@testable import RSSApp
+
+/// A `URLSessionDataProviding` mock that returns a configurable JSON payload and
+/// HTTP status code without hitting the network.
+///
+/// Uses a custom `URLProtocol` subclass so the returned `(Data, URLResponse)` pair
+/// is a real Foundation object — no wrapper types or protocol signature changes needed.
+/// Per-request data is keyed by a unique identifier injected via a custom HTTP header,
+/// making concurrent test execution safe.
+// RATIONALE: @unchecked Sendable is safe because this mock is only used in
+// single-threaded test contexts where properties are set before the async call.
+final class MockURLSessionDataProvider: URLSessionDataProviding, @unchecked Sendable {
+
+    /// Raw JSON payload to return in the response body.
+    var jsonPayload: Data = Data()
+
+    /// HTTP status code for the mock response (default 200).
+    var statusCode: Int = 200
+
+    /// When set, the mock throws this error instead of returning a response.
+    var throwError: Error?
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        if let error = throwError {
+            throw error
+        }
+
+        let requestID = UUID().uuidString
+
+        MockDataURLProtocol.store(
+            requestID: requestID,
+            payload: jsonPayload,
+            statusCode: statusCode
+        )
+
+        var mutableRequest = request
+        mutableRequest.setValue(requestID, forHTTPHeaderField: MockDataURLProtocol.requestIDHeader)
+
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockDataURLProtocol.self]
+        let session = URLSession(configuration: config)
+
+        return try await session.data(for: mutableRequest)
+    }
+}
+
+// MARK: - URLProtocol subclass
+
+/// Intercepts requests tagged with the mock request-ID header and returns the
+/// corresponding JSON payload from a thread-safe in-memory store.
+final class MockDataURLProtocol: URLProtocol {
+
+    static let requestIDHeader = "X-MockData-RequestID"
+
+    // MARK: - Thread-safe per-request store
+
+    private struct RequestData {
+        let payload: Data
+        let statusCode: Int
+    }
+
+    // RATIONALE: nonisolated(unsafe) is acceptable here because all access goes
+    // through the synchronized `storeQueue` dispatch queue below.
+    nonisolated(unsafe) private static var requestStore: [String: RequestData] = [:]
+    private static let storeQueue = DispatchQueue(label: "MockDataURLProtocol.storeQueue")
+
+    static func store(requestID: String, payload: Data, statusCode: Int) {
+        storeQueue.sync {
+            requestStore[requestID] = RequestData(payload: payload, statusCode: statusCode)
+        }
+    }
+
+    private static func retrieve(requestID: String) -> RequestData? {
+        storeQueue.sync {
+            requestStore.removeValue(forKey: requestID)
+        }
+    }
+
+    // MARK: - URLProtocol overrides
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        request.value(forHTTPHeaderField: requestIDHeader) != nil
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let requestID = request.value(forHTTPHeaderField: Self.requestIDHeader) else {
+            assertionFailure("MockDataURLProtocol: request missing \(Self.requestIDHeader) header")
+            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+            return
+        }
+        guard let data = Self.retrieve(requestID: requestID) else {
+            assertionFailure("MockDataURLProtocol: no stored data for requestID '\(requestID)'")
+            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+            return
+        }
+        guard let url = request.url else {
+            assertionFailure("MockDataURLProtocol: request has no URL")
+            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+        guard let response = HTTPURLResponse(
+            url: url,
+            statusCode: data.statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"]
+        ) else {
+            assertionFailure("MockDataURLProtocol: failed to create HTTPURLResponse")
+            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+            return
+        }
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: data.payload)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    // RATIONALE: Data is delivered synchronously in startLoading(); nothing to cancel.
+    override func stopLoading() {}
+}

--- a/RSSAppTests/Services/GeminiModelServiceTests.swift
+++ b/RSSAppTests/Services/GeminiModelServiceTests.swift
@@ -1,0 +1,225 @@
+import Foundation
+import Testing
+@testable import RSSApp
+
+@Suite("GeminiModelService")
+struct GeminiModelServiceTests {
+
+    // MARK: - Helpers
+
+    private func makeService(mock: MockURLSessionDataProvider) -> GeminiModelService {
+        GeminiModelService(session: mock)
+    }
+
+    private func makePayload(_ models: [[String: Any]]) throws -> Data {
+        let body: [String: Any] = ["models": models]
+        return try JSONSerialization.data(withJSONObject: body)
+    }
+
+    private func modelJSON(
+        name: String,
+        displayName: String? = nil,
+        supportedMethods: [String]? = nil
+    ) -> [String: Any] {
+        var dict: [String: Any] = ["name": name]
+        if let displayName { dict["displayName"] = displayName }
+        if let supportedMethods { dict["supportedGenerationMethods"] = supportedMethods }
+        return dict
+    }
+
+    // MARK: - Request headers
+
+    @Test("fetchModels sends x-goog-api-key header")
+    func requestSendsAPIKeyHeader() async throws {
+        let mock = MockURLSessionDataProvider()
+        mock.jsonPayload = try makePayload([])
+        var capturedRequest: URLRequest?
+
+        // Use a closure-based approach: intercept via MockDataURLProtocol's
+        // request-capture path by observing which key was injected via a thin
+        // wrapper mock that records the request before delegating.
+        final class CapturingProvider: URLSessionDataProviding, @unchecked Sendable {
+            var captured: URLRequest?
+            let inner: MockURLSessionDataProvider
+            init(inner: MockURLSessionDataProvider) { self.inner = inner }
+            func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+                captured = request
+                return try await inner.data(for: request)
+            }
+        }
+
+        let capturing = CapturingProvider(inner: mock)
+        let service = GeminiModelService(session: capturing)
+        _ = try await service.fetchModels(apiKey: "AIzaSy-test-key")
+        capturedRequest = capturing.captured
+
+        #expect(capturedRequest?.value(forHTTPHeaderField: "x-goog-api-key") == "AIzaSy-test-key")
+        #expect(capturedRequest?.value(forHTTPHeaderField: "accept") == "application/json")
+    }
+
+    // MARK: - Response parsing
+
+    @Test("fetchModels returns models that support generateContent")
+    func returnsFilteredModels() async throws {
+        let mock = MockURLSessionDataProvider()
+        mock.jsonPayload = try makePayload([
+            modelJSON(
+                name: "models/gemini-2.5-flash",
+                displayName: "Gemini 2.5 Flash",
+                supportedMethods: ["generateContent", "countTokens"]
+            ),
+            modelJSON(
+                name: "models/embedding-001",
+                displayName: "Embedding 001",
+                supportedMethods: ["embedContent"]
+            ),
+        ])
+
+        let service = makeService(mock: mock)
+        let models = try await service.fetchModels(apiKey: "key")
+
+        #expect(models.count == 1)
+        #expect(models[0].id == "gemini-2.5-flash")
+        #expect(models[0].displayName == "Gemini 2.5 Flash")
+    }
+
+    @Test("fetchModels strips the 'models/' prefix from the name field")
+    func stripsModelsPrefix() async throws {
+        let mock = MockURLSessionDataProvider()
+        mock.jsonPayload = try makePayload([
+            modelJSON(
+                name: "models/gemini-2.5-pro",
+                displayName: "Gemini 2.5 Pro",
+                supportedMethods: ["generateContent"]
+            ),
+        ])
+
+        let service = makeService(mock: mock)
+        let models = try await service.fetchModels(apiKey: "key")
+
+        #expect(models.count == 1)
+        #expect(models[0].id == "gemini-2.5-pro")
+    }
+
+    @Test("fetchModels uses raw name when 'models/' prefix is absent")
+    func handlesNameWithoutPrefix() async throws {
+        let mock = MockURLSessionDataProvider()
+        mock.jsonPayload = try makePayload([
+            modelJSON(
+                name: "gemini-experimental",
+                displayName: "Gemini Experimental",
+                supportedMethods: ["generateContent"]
+            ),
+        ])
+
+        let service = makeService(mock: mock)
+        let models = try await service.fetchModels(apiKey: "key")
+
+        #expect(models.count == 1)
+        #expect(models[0].id == "gemini-experimental")
+    }
+
+    @Test("fetchModels falls back to id when displayName is absent")
+    func fallsBackToIDForDisplayName() async throws {
+        let mock = MockURLSessionDataProvider()
+        mock.jsonPayload = try makePayload([
+            modelJSON(
+                name: "models/gemini-no-name",
+                supportedMethods: ["generateContent"]
+            ),
+        ])
+
+        let service = makeService(mock: mock)
+        let models = try await service.fetchModels(apiKey: "key")
+
+        #expect(models.count == 1)
+        #expect(models[0].displayName == "gemini-no-name")
+    }
+
+    @Test("fetchModels excludes models with no supportedGenerationMethods")
+    func excludesModelsWithoutMethods() async throws {
+        let mock = MockURLSessionDataProvider()
+        mock.jsonPayload = try makePayload([
+            modelJSON(
+                name: "models/gemini-mystery",
+                displayName: "Mystery"
+                // no supportedGenerationMethods key
+            ),
+        ])
+
+        let service = makeService(mock: mock)
+        let models = try await service.fetchModels(apiKey: "key")
+
+        #expect(models.isEmpty)
+    }
+
+    @Test("fetchModels returns empty array when models array is empty")
+    func emptyModelsArray() async throws {
+        let mock = MockURLSessionDataProvider()
+        mock.jsonPayload = try makePayload([])
+
+        let service = makeService(mock: mock)
+        let models = try await service.fetchModels(apiKey: "key")
+
+        #expect(models.isEmpty)
+    }
+
+    @Test("fetchModels returns empty array when models key is absent")
+    func missingModelsKey() async throws {
+        let mock = MockURLSessionDataProvider()
+        mock.jsonPayload = try JSONSerialization.data(withJSONObject: [String: Any]())
+
+        let service = makeService(mock: mock)
+        let models = try await service.fetchModels(apiKey: "key")
+
+        #expect(models.isEmpty)
+    }
+
+    // MARK: - HTTP error handling
+
+    @Test("fetchModels throws httpError for non-2xx status code")
+    func httpErrorStatusCode() async throws {
+        let mock = MockURLSessionDataProvider()
+        mock.statusCode = 403
+        mock.jsonPayload = Data()
+
+        let service = makeService(mock: mock)
+        await #expect(throws: AIServiceError.self) {
+            _ = try await service.fetchModels(apiKey: "key")
+        }
+    }
+
+    @Test("fetchModels throws httpError with the returned status code")
+    func httpErrorStatusCodeValue() async throws {
+        let mock = MockURLSessionDataProvider()
+        mock.statusCode = 401
+        mock.jsonPayload = Data()
+
+        let service = makeService(mock: mock)
+        do {
+            _ = try await service.fetchModels(apiKey: "key")
+            Issue.record("Expected fetchModels to throw")
+        } catch let error as AIServiceError {
+            guard case .httpError(let statusCode) = error else {
+                Issue.record("Expected httpError, got \(error)")
+                return
+            }
+            #expect(statusCode == 401)
+        } catch {
+            Issue.record("Unexpected error type: \(error)")
+        }
+    }
+
+    // MARK: - Network error propagation
+
+    @Test("fetchModels propagates network errors from the session")
+    func propagatesNetworkError() async throws {
+        let mock = MockURLSessionDataProvider()
+        mock.throwError = URLError(.notConnectedToInternet)
+
+        let service = makeService(mock: mock)
+        await #expect(throws: URLError.self) {
+            _ = try await service.fetchModels(apiKey: "key")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `URLSessionDataProviding` protocol abstracting `URLSession.data(for:)`, matching the `URLSessionBytesProviding` pattern already used by `GeminiAPIService` and `ClaudeAPIService`
- Injects the session into `GeminiModelService.init()` so the model-fetch path can be exercised without network access
- Adds `GeminiModelServiceTests` with 11 tests covering request headers, model filtering, prefix stripping, display name fallback, empty/missing response shapes, HTTP error propagation, and network error propagation

Closes #437

## Test plan
- [x] All 11 `GeminiModelServiceTests` pass
- [x] Project builds successfully for iOS Simulator (iPhone 17 Pro)