### PR TITLE
fix: Prevent reader spinner from sticking after article navigation (#442)

### DIFF
--- a/RSSApp/Views/ArticleReaderView.swift
+++ b/RSSApp/Views/ArticleReaderView.swift
@@ -229,7 +229,12 @@ struct ArticleReaderView: View {
     /// article as read. Invoked from `.onChange(of: article.articleID)` so the same handler
     /// covers normal navigation and the pagination boundary uniformly.
     private func onArticleChanged() {
-        extractionState = ReaderExtractionState()
+        // RATIONALE: Mutate the existing instance rather than replacing it. Replacing would
+        // break the Coordinator's reference: makeCoordinator() captures the current
+        // extractionState before .onChange fires, so the coordinator would write to the
+        // discarded instance and the view would observe a permanently-nil new instance,
+        // leaving the spinner stuck indefinitely.
+        extractionState.content = nil
         showSummary = false
         markCurrentArticleAsRead()
     }

--- a/RSSApp/Views/ArticleReaderView.swift
+++ b/RSSApp/Views/ArticleReaderView.swift
@@ -229,11 +229,15 @@ struct ArticleReaderView: View {
     /// article as read. Invoked from `.onChange(of: article.articleID)` so the same handler
     /// covers normal navigation and the pagination boundary uniformly.
     private func onArticleChanged() {
-        // RATIONALE: Mutate the existing instance rather than replacing it. Replacing would
-        // break the Coordinator's reference: makeCoordinator() captures the current
-        // extractionState before .onChange fires, so the coordinator would write to the
-        // discarded instance and the view would observe a permanently-nil new instance,
-        // leaving the spinner stuck indefinitely.
+        // RATIONALE: Mutate the existing instance rather than replacing it. `makeCoordinator()`
+        // is called once at view creation and permanently stores a reference to the original
+        // `ReaderExtractionState` object. Replacing `extractionState` allocates a new object;
+        // SwiftUI passes it to subsequent renders, but `updateUIView` is a no-op so the
+        // Coordinator never receives the replacement — it continues writing `content` to the
+        // old object while the view reads `isExtracting` from the new (always-nil) one,
+        // leaving the spinner stuck indefinitely. If `ReaderExtractionState` gains additional
+        // properties, each must be explicitly reset here — unlike replacement, mutation does
+        // not auto-reset new fields.
         extractionState.content = nil
         showSummary = false
         markCurrentArticleAsRead()

--- a/RSSApp/Views/ArticleReaderWebView.swift
+++ b/RSSApp/Views/ArticleReaderWebView.swift
@@ -68,6 +68,11 @@ struct ArticleReaderWebView: UIViewRepresentable {
         private let contentExtractor: any ContentExtracting
 
         /// Tracks whether early extraction already succeeded, so `didFinish` can skip redundant work.
+        // RATIONALE: Reset implicitly on article navigation because ArticleReaderView applies
+        // .id(article.articleID) to the ArticleReaderWebView subtree, causing SwiftUI to tear
+        // down and recreate the Coordinator (and this flag) on every article change. Removing
+        // that .id modifier would leave this flag stale across navigations, causing extraction
+        // to be skipped for subsequent articles and the spinner to get stuck.
         private var earlyExtractionSucceeded = false
 
         init(


### PR DESCRIPTION
## Summary
- Navigating between articles (up/down arrows) left the extraction spinner permanently stuck, blocking access to the AI summary button
- Root cause: `onArticleChanged()` replaced `extractionState` with a new `ReaderExtractionState()` instance, but the `Coordinator` already captured a reference to the old instance — it wrote extracted content there while the view observed the new (always-nil) instance
- Fix: mutate the existing instance (`extractionState.content = nil`) instead of replacing it, preserving the Coordinator's reference

Fixes #442

## Test plan
- [ ] Navigate between articles using up/down arrows — spinner completes and AI button appears
- [ ] Initial article load still works (spinner shows then resolves)
- [ ] All existing tests pass