### PR TITLE
refactor: Consolidate URLSession protocols into URLSessionProviding.swift (#441)

### DIFF
--- a/RSSApp/Services/ClaudeAPIService.swift
+++ b/RSSApp/Services/ClaudeAPIService.swift
@@ -1,20 +1,6 @@
 import Foundation
 import os
 
-/// Abstracts URLSession's `bytes(for:)` so `ClaudeAPIService` and `GeminiAPIService`
-/// can be tested with controlled SSE line sequences without hitting the network.
-protocol URLSessionBytesProviding: Sendable {
-    func bytes(for request: URLRequest, delegate: (any URLSessionTaskDelegate)?) async throws -> (URLSession.AsyncBytes, URLResponse)
-}
-
-extension URLSessionBytesProviding {
-    func bytes(for request: URLRequest) async throws -> (URLSession.AsyncBytes, URLResponse) {
-        try await bytes(for: request, delegate: nil)
-    }
-}
-
-extension URLSession: URLSessionBytesProviding {}
-
 /// Result of parsing a single SSE data line.
 ///
 /// Distinguishes between successfully extracted text, intentionally skipped

--- a/RSSApp/Services/GeminiModelService.swift
+++ b/RSSApp/Services/GeminiModelService.swift
@@ -1,16 +1,6 @@
 import Foundation
 import os
 
-// MARK: - URLSessionDataProviding
-
-/// Abstracts URLSession's `data(for:)` so services like `GeminiModelService`
-/// can be tested with controlled response payloads without hitting the network.
-protocol URLSessionDataProviding: Sendable {
-    func data(for request: URLRequest) async throws -> (Data, URLResponse)
-}
-
-extension URLSession: URLSessionDataProviding {}
-
 // MARK: - GeminiModel
 
 struct GeminiModel: Sendable, Identifiable, Hashable {

--- a/RSSApp/Services/URLSessionProviding.swift
+++ b/RSSApp/Services/URLSessionProviding.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+// MARK: - URLSessionBytesProviding
+
+/// Abstracts URLSession's `bytes(for:)` so `ClaudeAPIService` and `GeminiAPIService`
+/// can be tested with controlled SSE line sequences without hitting the network.
+protocol URLSessionBytesProviding: Sendable {
+    func bytes(for request: URLRequest, delegate: (any URLSessionTaskDelegate)?) async throws -> (URLSession.AsyncBytes, URLResponse)
+}
+
+extension URLSessionBytesProviding {
+    func bytes(for request: URLRequest) async throws -> (URLSession.AsyncBytes, URLResponse) {
+        try await bytes(for: request, delegate: nil)
+    }
+}
+
+extension URLSession: URLSessionBytesProviding {}
+
+// MARK: - URLSessionDataProviding
+
+/// Abstracts URLSession's `data(for:)` so services like `GeminiModelService`
+/// can be tested with controlled response payloads without hitting the network.
+protocol URLSessionDataProviding: Sendable {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: URLSessionDataProviding {}

--- a/RSSApp/Services/URLSessionProviding.swift
+++ b/RSSApp/Services/URLSessionProviding.swift
@@ -2,8 +2,8 @@ import Foundation
 
 // MARK: - URLSessionBytesProviding
 
-/// Abstracts URLSession's `bytes(for:)` so `ClaudeAPIService` and `GeminiAPIService`
-/// can be tested with controlled SSE line sequences without hitting the network.
+/// Abstracts URLSession's `bytes(for:)` to enable unit testing of streaming SSE consumers
+/// with controlled line sequences without hitting the network.
 protocol URLSessionBytesProviding: Sendable {
     func bytes(for request: URLRequest, delegate: (any URLSessionTaskDelegate)?) async throws -> (URLSession.AsyncBytes, URLResponse)
 }
@@ -18,7 +18,7 @@ extension URLSession: URLSessionBytesProviding {}
 
 // MARK: - URLSessionDataProviding
 
-/// Abstracts URLSession's `data(for:)` so services like `GeminiModelService`
+/// Abstracts URLSession's `data(for:)` so `GeminiModelService`
 /// can be tested with controlled response payloads without hitting the network.
 protocol URLSessionDataProviding: Sendable {
     func data(for request: URLRequest) async throws -> (Data, URLResponse)


### PR DESCRIPTION
## Summary
- Moves `URLSessionBytesProviding` and `URLSessionDataProviding` from individual service files into a single shared `RSSApp/Services/URLSessionProviding.swift`
- Eliminates parallel-definition risk as more services adopt injectable sessions
- Makes both protocols discoverable in one place rather than buried in unrelated service files
- Pure refactor — no behavior change

Closes #441

## Test plan
- [x] Built successfully for iOS 26 (no errors or warnings)
- [x] No behavior change — protocol declarations, default-delegate extension, and `URLSession` conformances identical; only location changed