### PR TITLE
fix: Show "Updated [relative time]" date text for unread updated articles (#446)

### DIFF
--- a/RSSApp/Views/ArticleRowView.swift
+++ b/RSSApp/Views/ArticleRowView.swift
@@ -69,9 +69,10 @@ struct ArticleRowView: View {
     ///
     /// The orange "Updated" capsule badge is appended when `wasUpdated` is true,
     /// without an `isRead` gate. `upsertArticles` sets `wasUpdated = true` while
-    /// the article is unread; `markRead` clears `wasUpdated` before setting
-    /// `isRead = true`, so the badge is only ever visible on unread articles —
-    /// suppressing it behind `isRead` would make it permanently invisible.
+    /// the article is unread; all mark-read transitions clear `wasUpdated` before
+    /// setting `isRead = true`, so the badge is only ever visible on unread
+    /// articles — suppressing it behind `isRead` would make it permanently
+    /// invisible.
     @ViewBuilder
     private var metadataFooter: some View {
         HStack(alignment: .firstTextBaseline, spacing: 6) {

--- a/RSSApp/Views/ArticleRowView.swift
+++ b/RSSApp/Views/ArticleRowView.swift
@@ -58,14 +58,14 @@ struct ArticleRowView: View {
     ///
     ///     [icon] Feed title · Apr 8                          [bookmark]
     ///     [icon] Feed title · Updated 3 hours ago            [bookmark]
-    ///     [icon] Feed title · Apr 8  [Updated]               [bookmark]
+    ///     [icon] Feed title · Updated 3 hours ago  [Updated] [bookmark]
     ///
     /// A middle dot (`·`) separates the feed name from the date or updated
-    /// text. When `isRead && shouldShowUpdatedSuffix` is true the dot precedes
-    /// the relative freshness string; otherwise it precedes the absolute publish
-    /// date. The `isRead` gate prevents "Updated 3 hours ago" from appearing on
-    /// articles the user has never opened — that label implies the user saw an
-    /// earlier version, which is meaningless before first read.
+    /// text. When `shouldShowUpdatedSuffix` is true the dot precedes the
+    /// relative freshness string; otherwise it precedes the absolute publish
+    /// date. The `isRead` gate was removed so unread+updated articles show
+    /// "Updated 3 hours ago" alongside the orange badge, giving the user
+    /// the most relevant time context regardless of read state.
     ///
     /// The orange "Updated" capsule badge is appended when `wasUpdated` is true,
     /// without an `isRead` gate. `upsertArticles` sets `wasUpdated = true` while
@@ -79,7 +79,7 @@ struct ArticleRowView: View {
             Text("·")
                 .foregroundStyle(.tertiary)
                 .accessibilityHidden(true)
-            if article.isRead && article.shouldShowUpdatedSuffix, let updated = article.updatedDate {
+            if article.shouldShowUpdatedSuffix, let updated = article.updatedDate {
                 Text("Updated \(updated, format: .relative(presentation: .named))")
             } else {
                 Text(publishDateText)


### PR DESCRIPTION
## Summary
- Unread+updated articles now show "Updated 3 hours ago" alongside the orange "Updated" badge instead of the stale publish date
- The `isRead` gate was removed from the `shouldShowUpdatedSuffix` condition; relative update time is now shown for both unread and read updated articles

Fixes #446

## Test plan
- [x] Built successfully for iOS 26
- [x] All existing tests pass