### PR TITLE
fix: Improve read article contrast by dimming description and footer text

### DIFF
--- a/RSSApp/Views/ArticleRowView.swift
+++ b/RSSApp/Views/ArticleRowView.swift
@@ -43,7 +43,7 @@ struct ArticleRowView: View {
 
                 Text(article.snippet)
                     .font(.subheadline)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(article.isRead ? .tertiary : .secondary)
                     .lineLimit(2)
 
                 metadataFooter
@@ -97,7 +97,7 @@ struct ArticleRowView: View {
             savedIndicator
         }
         .font(.caption)
-        .foregroundStyle(.secondary)
+        .foregroundStyle(article.isRead ? .tertiary : .secondary)
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- Read articles now show a clear visual hierarchy: the description snippet and metadata footer shift from `.secondary` to `.tertiary` when `isRead` is true, preserving the same title-to-body contrast as unread articles
- Unread articles retain `.secondary` styling for description and footer, unchanged from before

Fixes #448

## Changes
- `RSSApp/Views/ArticleRowView.swift`: Updated snippet `foregroundStyle` to use `.tertiary` when article is read
- `RSSApp/Views/ArticleRowView.swift`: Updated `metadataFooter` `foregroundStyle` to use `.tertiary` when article is read

## Test plan
- [x] Built successfully for iOS 26
- [x] All existing tests pass
- [ ] Visual: read articles show dimmer description/footer relative to title; unread articles unchanged