### PR TITLE
fix: Preserve scroll position in GroupArticleSource when toggling sort or unread filter (#452)

### DIFF
--- a/RSSApp/ViewModels/GroupArticleSource.swift
+++ b/RSSApp/ViewModels/GroupArticleSource.swift
@@ -40,20 +40,20 @@ final class GroupArticleSource: ArticleListSource {
     // RATIONALE: sortAscending delegates to homeViewModel.sortAscending, which is itself
     // backed by Settings.UserDefaultsKeys.sortAscending. @Observable does not track
     // UserDefaults reads automatically; UI correctness is preserved because the setter
-    // calls loadArticles(), which mutates the tracked `articles` array and drives SwiftUI
+    // calls reloadArticles(), which mutates the tracked `articles` array and drives SwiftUI
     // updates.
     var sortAscending: Bool {
         get { homeViewModel.sortAscending }
         set {
             homeViewModel.sortAscending = newValue
-            loadArticles()
+            reloadArticles()
         }
     }
 
     // RATIONALE: showUnreadOnly is backed by Settings.UserDefaultsKeys.showUnreadOnly, the
     // same global key used by FeedViewModel.showUnreadOnly, so the toggle state is shared
     // across all feed and group article lists. @Observable does not track UserDefaults reads
-    // automatically; UI correctness is preserved because the setter calls loadArticles(),
+    // automatically; UI correctness is preserved because the setter calls reloadArticles(),
     // which mutates the tracked `articles` array and drives SwiftUI updates.
     var showUnreadOnly: Bool {
         get { userDefaults.bool(forKey: Settings.UserDefaultsKeys.showUnreadOnly) }
@@ -61,7 +61,7 @@ final class GroupArticleSource: ArticleListSource {
             guard userDefaults.bool(forKey: Settings.UserDefaultsKeys.showUnreadOnly) != newValue else { return }
             userDefaults.set(newValue, forKey: Settings.UserDefaultsKeys.showUnreadOnly)
             Self.logger.debug("showUnreadOnly changed to \(newValue, privacy: .public)")
-            loadArticles()
+            reloadArticles()
         }
     }
 
@@ -142,6 +142,38 @@ final class GroupArticleSource: ArticleListSource {
     /// cursor-based pagination. Reset to `nil` on full reload (sort change,
     /// refresh) so the first page re-fetches from the start.
     private var paginationCursor: ArticlePaginationCursor?
+
+    /// Reloads the article list from the beginning, preserving the current display depth.
+    /// Fetches `max(articles.count, pageSize)` articles from the start in a single call so
+    /// the user stays near their current scroll position after toggling sort or filter —
+    /// mirroring the behavior of `FeedViewModel.reloadArticles()`.
+    private func reloadArticles() {
+        let reloadLimit = max(articles.count, HomeViewModel.pageSize)
+        let ascending = sortAscending
+        let unreadOnly = showUnreadOnly
+        do {
+            let page = try unreadOnly
+                ? persistence.unreadArticles(
+                    in: group,
+                    cursor: nil,
+                    limit: reloadLimit,
+                    ascending: ascending
+                )
+                : persistence.articles(
+                    in: group,
+                    cursor: nil,
+                    limit: reloadLimit,
+                    ascending: ascending
+                )
+            articles = page
+            paginationCursor = page.last.map(ArticlePaginationCursor.init)
+            hasMore = page.count == reloadLimit
+            Self.logger.debug("Reloaded \(page.count, privacy: .public) articles for group '\(self.group.name, privacy: .public)' (limit: \(reloadLimit, privacy: .public))")
+        } catch {
+            errorMessage = "Unable to reload articles."
+            Self.logger.error("Failed to reload articles for group '\(self.group.name, privacy: .public)': \(error, privacy: .public)")
+        }
+    }
 
     private func loadArticles() {
         let previous = articles

--- a/RSSAppTests/ViewModels/GroupArticleSourceTests.swift
+++ b/RSSAppTests/ViewModels/GroupArticleSourceTests.swift
@@ -253,7 +253,42 @@ struct GroupArticleSourceTests {
         #expect(firstDescending != firstAscending)
     }
 
+    @Test("sortAscending toggle preserves scroll depth when multi-page list is loaded")
+    @MainActor
+    func sortAscendingTogglePreservesScrollDepth() {
+        // 60 articles across 2 feeds — exceeds pageSize (50), so two pages must be loaded first.
+        let (source, _, _, _) = Self.makeFixture(articleCount: 30, feedCount: 2)
+        source.reload()
+        #expect(source.articles.count == 50)
+        _ = source.loadMoreAndReport()
+        #expect(source.articles.count == 60)
+
+        // Toggling sort should reload up to the current depth (60), not collapse to one page (50).
+        source.sortAscending = true
+        #expect(source.articles.count == 60)
+        #expect(source.articles.allSatisfy { _ in true }) // no duplicates check below
+        let ids = source.articles.map(\.articleID)
+        #expect(Set(ids).count == ids.count)
+    }
+
     // MARK: - Unread filter
+
+    @Test("showUnreadOnly toggle preserves scroll depth when multi-page list is loaded")
+    @MainActor
+    func showUnreadOnlyTogglePreservesScrollDepth() {
+        // 120 unread articles across 2 feeds — exceeds pageSize (50), so two pages must be loaded first.
+        let (source, _, _, _) = Self.makeFixture(articleCount: 60, feedCount: 2, readCount: 0)
+        source.reload()
+        #expect(source.articles.count == 50)
+        _ = source.loadMoreAndReport()
+        #expect(source.articles.count == 100)
+
+        // Toggling showUnreadOnly on should reload up to the current depth (100), not collapse to one page.
+        source.showUnreadOnly = true
+        #expect(source.articles.count == 100)
+        let ids = source.articles.map(\.articleID)
+        #expect(Set(ids).count == ids.count)
+    }
 
     @Test("showUnreadOnly filters to unread articles only")
     @MainActor


### PR DESCRIPTION
## Summary
- Toggling sort order or unread filter in a group article list no longer scrolls to the top — the loaded article count is preserved across the toggle, matching the existing behavior of `FeedViewModel`
- Adds a private `reloadArticles()` method to `GroupArticleSource` mirroring `FeedViewModel.reloadArticles()`: fetches `max(articles.count, pageSize)` articles from `cursor: nil` in a single call, replacing the list and setting the cursor to the last article

## Changes
- `RSSApp/ViewModels/GroupArticleSource.swift` — add `reloadArticles()`, update `sortAscending` and `showUnreadOnly` setters to call it instead of `loadArticles()`
- `RSSAppTests/ViewModels/GroupArticleSourceTests.swift` — add `sortAscendingTogglePreservesScrollDepth` and `showUnreadOnlyTogglePreservesScrollDepth` tests

## Test plan
- [x] All 20 GroupArticleSourceTests pass
- [x] New tests verify the loaded count (100 articles) is preserved after toggling sort/filter on a 2-page list
- [x] Existing error-handling, pagination, and filter tests unchanged and passing

Closes #452